### PR TITLE
fix annotate

### DIFF
--- a/GCodeClean/Processing/Processing.cs
+++ b/GCodeClean/Processing/Processing.cs
@@ -435,12 +435,19 @@ namespace GCodeClean.Processing
                 {
                     context.BuildContext(tokenDefinitions, token);
 
-                    var annotation = tokenDefs.GetProperty(token.ToString()).GetString();
+                    string annotation = null;
+                    if (tokenDefs.TryGetProperty(token.ToString(), out var tokenDef))
+                    {
+                        annotation = tokenDef.GetString();
+                    }
                     if (annotation is null && token.Number.HasValue)
                     {
                         var subToken = "" + token.Code;
                         tokenCodes.Add(subToken);
-                        annotation = tokenDefs.GetProperty(subToken).GetString();
+                        if (tokenDefs.TryGetProperty(subToken, out var subTokenDef))
+                        {
+                            annotation = subTokenDef.GetString();
+                        }
                         context[token.Code + "value"] = token.Number.Value.ToString(CultureInfo.InvariantCulture);
                     }
                     else


### PR DESCRIPTION
Annotate didn't support GCode tokens that were not in the TokenDefinitions file.

The correct behavior was for it to ignore them and pass them through to the output unchanged.

This also includes a test for this behavior