### PR TITLE
Handle a changing `context` everywhere

### DIFF
--- a/GCodeClean.Tests/Dedup.Tests.cs
+++ b/GCodeClean.Tests/Dedup.Tests.cs
@@ -158,16 +158,13 @@ namespace GCodeClean.Tests
                 new Line("M30"),
             };
 
-            var lengthUnits = Utility.GetLengthUnits(Default.Preamble());
-            var coordPlane = Default.Preamble().GetModalState(ModalGroup.ModalPlane).ToString();
-
             // A Test with fine tolerance
-            var resultLinesA = await lines.DedupLinearToArc(lengthUnits, coordPlane, 0.005M).ToListAsync();
+            var resultLinesA = await lines.DedupLinearToArc(0.005M).ToListAsync();
             Assert.False(sourceLines.SequenceEqual(resultLinesA));
             Assert.True(expectedLinesA.SequenceEqual(resultLinesA));
 
             // B Test with coarse tolerance
-            var resultLinesB = await lines.DedupLinearToArc(lengthUnits, coordPlane, 0.5M).ToListAsync();
+            var resultLinesB = await lines.DedupLinearToArc(0.5M).ToListAsync();
             Assert.False(sourceLines.SequenceEqual(resultLinesB));
             Assert.True(expectedLinesB.SequenceEqual(resultLinesB));
         }

--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -71,7 +71,7 @@ namespace GCodeClean.Tests
             // Note: that cleaning up the redundant preamble context above is performed by DedupContext
 
             var firstPhaseLines = sourceLines.ProcessLinesFirstPhase(false);
-            var preambleContext = await firstPhaseLines.BuildPreamble(Default.Preamble());
+            var preambleContext = await firstPhaseLines.BuildPreamble();
 
             var resultLines = await lines.InjectPreamble(preambleContext, zClamp).ToListAsync();
             Assert.False(sourceLineLines.SequenceEqual(resultLines));
@@ -117,7 +117,7 @@ namespace GCodeClean.Tests
             var setHeight = 1.1M;
 
             var firstPhaseLines = sourceLines.ProcessLinesFirstPhase(false);
-            var preambleContext = await firstPhaseLines.BuildPreamble(Default.Preamble());
+            var preambleContext = await firstPhaseLines.BuildPreamble();
 
             var adjustedHeight = Utility.ConstrictZClamp(Utility.GetLengthUnits(preambleContext), setHeight);
             var expectedLines = new List<Line> { new Line("G20"), new Line("G90"), new Line($"G0 Z{adjustedHeight}"), new Line($"G0 Z{adjustedHeight}"), new Line($"G0 Z{adjustedHeight} F30"), new Line("G1 Z-0.15") };
@@ -135,9 +135,7 @@ namespace GCodeClean.Tests
             var testLines = sourceLines.ConvertAll(l => new Line(l));
             var lines = AsyncLines(testLines);
 
-            var lengthUnits = Utility.GetLengthUnits(Default.Preamble());
-
-            var resultLines = await lines.Clip(lengthUnits).ToListAsync();
+            var resultLines = await lines.Clip().ToListAsync();
             Assert.False(sourceLines.SequenceEqual(resultLines));
         }
 

--- a/GCodeClean/Processing/Utility.cs
+++ b/GCodeClean/Processing/Utility.cs
@@ -62,11 +62,24 @@ namespace GCodeClean.Processing
             return decimalPlaces;
         }
 
-        public static string GetLengthUnits(Context context)
+        /// <summary>
+        /// Get the length units from the context
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static string GetLengthUnits(this Context context)
         {
             var unitsCommand = context.GetModalState(ModalGroup.ModalUnits);
-
             return unitsCommand == null || unitsCommand.ToString() == "G20" ? "inch" : "mm";
+        }
+
+        /// <summary>
+        /// Get the length units from the context
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static string GetCoordPlane(this Context context) {
+            return context.GetModalState(ModalGroup.ModalPlane).ToString();
         }
 
         public static decimal ConstrictZClamp(string lengthUnits = "mm", decimal zClamp = 10.0M) {

--- a/GCodeClean/Processing/Workflow.cs
+++ b/GCodeClean/Processing/Workflow.cs
@@ -22,12 +22,12 @@ namespace GCodeClean.Processing
             JsonDocument tokenDefinitions
         ) {
             var firstPhaseLines = inputLines.ProcessLinesFirstPhase(lineNumbers);
-            var preambleContext = await firstPhaseLines.BuildPreamble(Default.Preamble());
-            var (lengthUnits, coordPlane, zClampContrained) = preambleContext.ExtractKeyInfo(zClamp);
-
+            // Determine our starting context
+            var preambleContext = await firstPhaseLines.BuildPreamble();
+ 
             var processedLines = firstPhaseLines
-                .PreAndPostamblePhase(preambleContext, zClampContrained)
-                .ProcessLinesSecondPhase(lengthUnits, coordPlane, zClampContrained, arcTolerance, tolerance)
+                .PreAndPostamblePhase(preambleContext, zClamp)
+                .ProcessLinesSecondPhase(zClamp, arcTolerance, tolerance)
                 .ProcessLinesThirdPhase(dedupSelection, annotate, tokenDefinitions);
 
             var reassembledLines = processedLines.ReassembleLines(minimisationStrategy);
@@ -60,20 +60,6 @@ namespace GCodeClean.Processing
         }
 
         /// <summary>
-        /// Get key information from the premable context now that we know what it is
-        /// </summary>
-        /// <param name="preambleContext"></param>
-        /// <param name="zClamp"></param>
-        /// <returns></returns>
-        public static (string lengthUnits, string coordPlane, decimal zClamp) ExtractKeyInfo(this Context preambleContext, decimal zClamp) {
-            var lengthUnits = Utility.GetLengthUnits(preambleContext);
-            zClamp = Utility.ConstrictZClamp(lengthUnits, zClamp);
-            var coordPlane = preambleContext.GetModalState(ModalGroup.ModalPlane).ToString();
-
-            return (lengthUnits, coordPlane, zClamp);
-        }
-
-        /// <summary>
         /// Inject the pre and postamble GCode lines to complete getting the GCode to a consistent state
         /// </summary>
         /// <param name="firstPhaseLines"></param>
@@ -98,27 +84,24 @@ namespace GCodeClean.Processing
         /// Do the actual processing of the GCode
         /// </summary>
         /// <param name="preAndPostamblePhaseLines"></param>
-        /// <param name="lengthUnits"></param>
-        /// <param name="coordPlane"></param>
         /// <param name="zClamp"></param>
         /// <param name="arcTolerance"></param>
         /// <param name="tolerance"></param>
         /// <returns></returns>
         public static async IAsyncEnumerable<Line> ProcessLinesSecondPhase(
             this IAsyncEnumerable<Line> preAndPostamblePhaseLines,
-            string lengthUnits,
-            string coordPlane,
             decimal zClamp,
             decimal arcTolerance,
             decimal tolerance
         ) {
             var secondPhaseLines = preAndPostamblePhaseLines
                 .ZClamp(zClamp)
-                .ConvertArcRadiusToCenter(coordPlane)
+                //.DedupTravelling()
+                .ConvertArcRadiusToCenter()
                 .DedupLine()
-                .SimplifyShortArcs(lengthUnits, arcTolerance)
-                .DedupLinearToArc(lengthUnits, coordPlane, tolerance)
-                .Clip(lengthUnits, tolerance)
+                .SimplifyShortArcs(arcTolerance)
+                .DedupLinearToArc(tolerance)
+                .Clip(tolerance)
                 .DedupRepeatedTokens()
                 .DedupLine()
                 .DedupLinear(tolerance);

--- a/GCodeClean/Structure/Line.cs
+++ b/GCodeClean/Structure/Line.cs
@@ -157,7 +157,7 @@ namespace GCodeClean.Structure
         /// </summary>
         public bool HasMovementCommand()
         {
-            return !IsArgumentsOnly() && HasTokens(ModalGroup.ModalSimpleMotion);
+            return !IsArgumentsOnly() && HasTokens(ModalGroup.ModalAllMotion);
         }
 
         public Line()


### PR DESCRIPTION
# Description

It was all supposed to be so simple ... 

As I was running through some tests (using a particularly nasty bit of GCode) I noticed that certain curves (from linear to arc deduplication) were scrambled, although most of them were fine.

And down the rabbit-hole I fell.

This particular nasty bit of GCode used multiple coordinate planes, so not just `G17`, but `G18` and `G19` also. Why? Really bad CAM programming I suspect, from the looks of what it was used for.

However, while GCodeClean has the maths to support this, I never really got it working, simply assuming that there would only ever be one coordinate plane in use for a whole file.

So now that I have the preamble context in a really sweet spot, I could get each function that needed to know the coordinate plane to define an initial context, and then update that line by line (of GCode) to always have the correct coordinate plane with which to feed into the processing. Hey presto 🎉 , linear to arc dedup suddenly works properly for all coordinate planes.

But that left another issue (cover your children's ears for this one), it's totally legal to change units in a GCode file, going from inch to mm and back again. Why anyone would want to do this is beyond me (utter perversity I'm guessing), but 'supporting' this abomination was 'the right thing to do' with regard to making the code cleaner and sticking to the NIST spec. So here it is...

Sometime soon I'll add a guard to detect the length unit change in the GCode, and have it connect to all bluetooth speakers in the vicinity getting them to scream obscenities at maximum volume, oh and also crash out the GCode clean up.