### PR TITLE
v1.0.5 - Eliminate Needless Travelling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/CLI/bin/Debug/net6.0/CLI.dll",
-            "args": ["--filename", "Samples/Facade/Facade.nc", "--minimise", "soft"],
+            "args": ["--filename", "../Samples/Facade/Facade.nc", "--minimise", "soft"],
             "cwd": "${workspaceFolder}/CLI",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",

--- a/CLI/Options.cs
+++ b/CLI/Options.cs
@@ -34,6 +34,9 @@ namespace GCodeCleanCLI
         [Option("zClamp", Required = false, HelpText = "Restrict z-axis positive values to the supplied value")]
         public decimal zClamp { get; set; }
 
+        [Option("eliminateNeedlessTravelling", Required = false, HelpText = "Eliminate needless 'travelling', extra movements with positive z-axis values", Default = true)]
+        public bool eliminateNeedlessTravelling { get; set; }
+
         [Usage(ApplicationAlias = "GCodeClean")]
         public static IEnumerable<Example> Examples => new List<Example> {
             new Example("Clean GCode file", new Options { filename = "facade.nc" })

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -73,7 +73,7 @@ namespace GCodeCleanCLI
 
             (var minimisationStrategy, var dedupSelection) = Program.GetMinimisationStrategy(options.minimise, new List<char> { 'F', 'Z' });
 
-            var reassembledLines = inputLines.ProcessLines(dedupSelection, minimisationStrategy, options.lineNumbers, zClamp, arcTolerance, tolerance, options.annotate, tokenDefinitions);
+            var reassembledLines = inputLines.ProcessLines(dedupSelection, minimisationStrategy, options.lineNumbers, options.eliminateNeedlessTravelling, zClamp, arcTolerance, tolerance, options.annotate, tokenDefinitions);
             var lineCount = outputFile.WriteLinesAsync(reassembledLines);
 
             await foreach (var line in lineCount)

--- a/README.md
+++ b/README.md
@@ -38,28 +38,31 @@ USAGE:
 Clean GCode file:
   GCodeClean --filename facade.nc
 
-  --filename        Required. Full path to the input filename.
+  --filename                       Required. Full path to the input filename.
 
-  --tokenDefs       (Default: tokenDefinitions.json) Full path to the tokenDefinitions.json file.
+  --tokenDefs                      (Default: tokenDefinitions.json) Full path to the tokenDefinitions.json file.
 
-  --annotate        (Default: false) Annotate the GCode with inline comments.
+  --annotate                       Annotate the GCode with inline comments.
 
-  --lineNumbers     (Default: false) Keep line numbers.
+  --lineNumbers                    (Default: false) Keep line numbers
 
-  --minimise        (Default: soft) Select preferred minimisation strategy, 'soft' - (default) FZ only, 'medium' - All
-                    codes excluding IJK (but leave spaces in place), 'hard' - All codes excluding IJK and remove spaces,
-                    or list of codes e.g. FGXYZ
+  --minimise                       (Default: soft) Select preferred minimisation strategy, 'soft' - (default) FZ only,
+                                   'medium' - All codes excluding IJK (but leave spaces in place), 'hard' - All codes
+                                   excluding IJK and remove spaces, or list of codes e.g. FGXYZ
 
-  --tolerance       (Default: 0.0005" or 0.005mm) Enter a clipping tolerance for the various deduplication operations
+  --tolerance                      Enter a clipping tolerance for the various deduplication operations
 
-  --arcTolerance    (Default: 0.0005" or 0.005mm) Enter a tolerance for the 'point-to-point' length of arcs (G2, G3) below which they will be
-                    converted to lines (G1)
+  --arcTolerance                   Enter a tolerance for the 'point-to-point' length of arcs (G2, G3) below which they will be
+                                   converted to lines (G1)
 
-  --zClamp          (Default: 0.02" or 0.5mm) Restrict z-axis positive values to the supplied value
+  --zClamp                         Restrict z-axis positive values to the supplied value
 
-  --help            Display this help screen.
+  --eliminateNeedlessTravelling    (Default: true) Eliminate needless 'travelling', extra movements with positive z-axis
+                                   values
 
-  --version         Display version information.
+  --help                           Display this help screen.
+
+  --version                        Display version information.
 
 Exit code=0
   
@@ -86,6 +89,8 @@ Exit code=0
 `--zClamp` accepts a value to 'clamp' all positive z-axis values.
   - 0.02 to 0.5 for inches or
   - 0.5 to 10.0 for millimeters
+
+`--eliminateNeedlessTravelling` is a simple switch. Normally needless travalling (intermediary `G0` with positive z-axis values) will be eliminated, but adding this flag and setting it to false will ensure they are preserved.
 
 For the tolerance and clamp values, the smallest value (inch or mm specific) is used as the default value.
 


### PR DESCRIPTION
# Description

This is one of those things that's been floating around for a while (as an idea), and I've finally done it.

Sometimes bad CAM will encode cutting paths (`G1`) that's actually above the surface of the work (i.e. they should be `G0`), maybe abuse of cutter compensation etc., but generally 'just bad programming'™️

Running the `zClamp` pass over the GCode will convert all such bad cutting paths to `G0`. Then this functionality can do its work to eliminate all of the intermediary `G0` movements that do nothing but waste time.

There's a new command line option `--eliminateNeedlessTravelling` with a default of `true`, including this option and setting it to `false` will let you keep these lines if there's some perverse reason (like bad CAM) that means you need to keep them.