### PR TITLE
v1.1.0 - Identify travelling

### DIFF
--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -173,7 +173,7 @@ namespace GCodeClean.Tests
             var expectedLines = new List<string> {
                 "G21 (Length units: Millimeters)",
                 "G90 (Set Distance Mode: Absolute)",
-                "G1 Z0.1568 F9 (Linear motion: at Feed Rate, Z0.1568mm, Set Feed Rate to {feedRateMode})",
+                "G1 Z0.1568 F9 (Linear motion: at Feed Rate, Z0.1568mm, Set Feed Rate to 9 {feedRateMode})",
                 "G1234"
             };
 

--- a/GCodeClean/Processing/Dedup.cs
+++ b/GCodeClean/Processing/Dedup.cs
@@ -10,6 +10,11 @@ using GCodeClean.Structure;
 namespace GCodeClean.Processing
 {
     public static class Dedup {
+        /// <summary>
+        /// Eliminates duplicate lines of GCode
+        /// </summary>
+        /// <param name="tokenisedLines"></param>
+        /// <returns></returns>
         public static async IAsyncEnumerable<Line> DedupLine(this IAsyncEnumerable<Line> tokenisedLines) {
             var previousLine = new Line();
             await foreach (var line in tokenisedLines) {
@@ -476,8 +481,7 @@ namespace GCodeClean.Processing
             }
 
             var linearMovementToken = new Token("G1");
-            lineB.RemoveToken(linearMovementToken);
-            lineB.PrependToken(new Token(prevIsClockwise ? "G2" : "G3"));
+            lineB.ReplaceToken(linearMovementToken, new Token(prevIsClockwise ? "G2" : "G3"));
 
             var centerX = new Token($"I{prevCenter.X - coordsA.X:0.####}");
             var centerY = new Token($"J{prevCenter.Y - coordsA.Y:0.####}");

--- a/GCodeClean/Processing/Default.cs
+++ b/GCodeClean/Processing/Default.cs
@@ -24,13 +24,14 @@ namespace GCodeClean.Processing
                     (new Line("G40"), false), // Cutter radius compensation, off - alternates are G41, G42
                     (new Line("G49"), false), // Tool length offset, none - alternate G43
                     (new Line("G54"), false), // Coordinate system selection - alternate G55, G56, G57, G58, G59, G59.1, G59.2, G59.3
+                    // (new Line("T1"), false), // Select tool 1 (arbitrary default)
+                    // (new Line("M6"), false), // Change tool
                     (new Line("M3"), false), // Spindle control, clockwise - alternates are M4, M5
                     // (new Line("G61"), false), // Path control mode, exact path - alternates are G61.1, G64
                     // (new Line("G80"), false), // Modal motion (AKA Canned Cycle), Cancel - alternates are G81, G82, G83, G84, G85, G86, G87, G88, G89
                     // (new Line("F"), false), // Feed rate, default will depend on length units
+                    // (new Line("G4 P2"), false), // Dwell, for 2 seconds - useful before any S command to allow the spindle to speed up
                     // (new Line("S"), false), // Spindle speed
-                    // (new Line("T"), false), // Select tool
-                    // (new Line("M6"), false), // Change tool
                     // (new Line("M7 M8"), false), // Coolant control, mist and flood - alternates are any one of M7, M8, M9 
                 }
             );

--- a/GCodeClean/Processing/Workflow.cs
+++ b/GCodeClean/Processing/Workflow.cs
@@ -110,6 +110,7 @@ namespace GCodeClean.Processing
                 .Clip(tolerance)
                 .DedupRepeatedTokens()
                 .DedupLine()
+                .DetectTravelling()
                 .DedupLinear(tolerance);
 
             await foreach (var line in secondPhaseLines) {

--- a/GCodeClean/Structure/Context.cs
+++ b/GCodeClean/Structure/Context.cs
@@ -45,6 +45,11 @@ namespace GCodeClean.Structure
             Lines = lines;
         }
 
+        /// <summary>
+        /// Update the context in execution order for each modal group
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="isOutput"></param>
         public void Update(Line line, bool isOutput = false)
         {
             UpdateModal(line, isOutput, ModalGroup.ModalFeedRate);
@@ -55,7 +60,7 @@ namespace GCodeClean.Structure
             UpdateModal(line, isOutput, ModalGroup.ModalSpindleTurning);
             // No support for Coolants in the context yet
             UpdateModal(line, isOutput, ModalGroup.ModalOverrideEnabling);
-            // Dwell (G4) - we don't care about here
+            // Dwell (G4) - we don't care about here - it's not a modal
             UpdateModal(line, isOutput, ModalGroup.ModalPlane);
             UpdateModal(line, isOutput, ModalGroup.ModalUnits);
             UpdateModal(line, isOutput, ModalGroup.ModalCutterRadiusCompensation);

--- a/GCodeClean/Structure/Line.cs
+++ b/GCodeClean/Structure/Line.cs
@@ -196,7 +196,7 @@ namespace GCodeClean.Structure
 
             // This little hack handles situations where we have an existing line number
             // If the supplied token is a line number, then the existing line number will be eliminated
-            // If the supplied toke is not a line number, then it will end up immediately after any line number
+            // If the supplied token is not a line number, then it will end up immediately after any line number
             _tokens = AllTokens;
         }
 
@@ -259,6 +259,22 @@ namespace GCodeClean.Structure
 
                 removedTokens.Add(_tokens[ix]);
                 _tokens.RemoveAt(ix);
+            }
+
+            return removedTokens;
+        }
+
+        public List<Token> ReplaceToken(Token searchToken, Token replaceToken) {
+            var removedTokens = new List<Token>();
+
+            for (var ix = _tokens.Count - 1; ix >= 0; ix--) {
+                if (searchToken != _tokens[ix]) {
+                    continue;
+                }
+
+                removedTokens.Add(_tokens[ix]);
+                _tokens.RemoveAt(ix);
+                _tokens.Insert(ix, replaceToken);
             }
 
             return removedTokens;

--- a/GCodeClean/Structure/ModalGroup.cs
+++ b/GCodeClean/Structure/ModalGroup.cs
@@ -32,7 +32,7 @@ namespace GCodeClean.Structure
             new Token("G92"), new Token("G92.1"), new Token("G92.2"), new Token("G92.3"));
 
         /// <summary>
-        /// Non-modal group 0 - These describe actions that have no effect (G4),
+        /// Non-modal group 0 - These describe actions that have no effect past the line they are on (G4, (P)),
         /// or that affect offsets only (G10, G92, G92.1, G92.2, G92.3) 
         /// </summary>
         /// <remarks>

--- a/GCodeClean/tokenDefinitions.json
+++ b/GCodeClean/tokenDefinitions.json
@@ -1,6 +1,11 @@
 {
 	"replaceableTokens": [
 		"feedRateMode",
+		"Fvalue",
+		"Ivalue",
+		"Jvalue",
+		"Kvalue",
+		"Pvalue",
 		"Svalue",
 		"Xvalue",
 		"Yvalue",
@@ -127,11 +132,11 @@
 
 		"D": "Tool Radius Compensation",
 		"E": "Extrude Filament",
-		"F": "Set Feed Rate to {feedRateMode}",
+		"F": "Set Feed Rate to {Fvalue} {feedRateMode}",
 		"H": "Tool Length Offset Index",
 		"L": "Canned Cycle: Number of Repetitions",
 		"N": "Line Number",
-		"P": "Canned Cycle: Dwell Time",
+		"P": "Dwell Time {Pvalue} seconds",
 		"R": "Arc Radius",
 		"S": "Set Spindle Speed {Svalue} rpm",
 		"T": "Select Tool",
@@ -144,9 +149,9 @@
 		"A": "A-Axis",
 		"B": "B-Axis",
 		"C": "C-Axis",
-		"I": "Arc Offset: X-Axis",
-		"J": "Arc Offset: Y-Axis",
-		"K": "Arc Offset: Z-Axis",
+		"I": "Arc Offset: X-Axis I{Ivalue}{lengthUnits}",
+		"J": "Arc Offset: Y-Axis J{Jvalue}{lengthUnits}",
+		"K": "Arc Offset: Z-Axis K{Kvalue}{lengthUnits}",
 		"X": "X{Xvalue}{lengthUnits}",
 		"Y": "Y{Yvalue}{lengthUnits}",
 		"Z": "Z{Zvalue}{lengthUnits}"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ But if you do build it yourself then there are a very large number of possible t
 Throw the `--help` command line option at the GCodeClean `CLI` (in other words type in `cli --help`) and you'll get back the following:
 
 ```
-CLI 1.0.3
+CLI 1.1.0
 Copyright (C) 2022 md8n
 USAGE:
 Clean GCode file:


### PR DESCRIPTION
# Description

A key step before file splitting and ultimately travelling path optimisation is to identify where travelling commences (and flag it in some way).

This :pr: does that. It also identifies the entry and exit points of the cut preceeding the travelling.