### PR TITLE
v1.2.2 - bug fixes, some code clean up, and ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Samples/
 .github/workflows/
 /CLI/Properties/launchSettings.json
 cli/Facade-gcc/*_gcc.nc
+GCodeSpec.pdf

--- a/CLI/CLI.csproj
+++ b/CLI/CLI.csproj
@@ -19,8 +19,8 @@ The primary objective is to be a `GCode Linter`.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +28,6 @@ The primary objective is to be a `GCode Linter`.</Description>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.8.0.76515" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.15.0.81779" />
   </ItemGroup>
 </Project>

--- a/CLI/Clean/CleanCommand.cs
+++ b/CLI/Clean/CleanCommand.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 using GCodeClean.IO;
 using GCodeClean.Processing;
+using GCodeClean.Structure;
 
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -50,7 +51,19 @@ namespace GCodeCleanCLI.Clean
                 ? "SOFT"
                 : minimise.ToUpperInvariant();
             if (!string.IsNullOrWhiteSpace(minimise) && minimisationStrategy != "SOFT") {
-                List<char> hardList = ['A', 'B', 'C', 'D', 'F', 'G', 'H', 'L', 'M', 'N', 'P', 'R', 'S', 'T', 'X', 'Y', 'Z'];
+                List<char> hardList = [
+                    'A', 'B', 'C',
+                    'D',
+                    Letter.feedRate,
+                    Letter.gCommand,
+                    'H', 'L',
+                    Letter.mCommand,
+                    Letter.lineNumber,
+                    'P', 'R',
+                    Letter.spindleSpeed,
+                    Letter.selectTool,
+                    'X', 'Y', 'Z'
+                ];
                 dedupSelection = minimisationStrategy == "HARD" || minimisationStrategy == "MEDIUM"
                     ? hardList
                     : new List<char>(minimisationStrategy).Intersect(hardList).ToList();
@@ -71,7 +84,7 @@ namespace GCodeCleanCLI.Clean
             var zClamp = ConstrainOption(settings.ZClamp, 0.02M, 10.0M, "Z-axis clamping value (max traveling height):");
             AnsiConsole.MarkupLine("[blue]All tolerance and clamping values may be further adjusted to allow for inches vs. millimeters[/]");
 
-            var (minimisationStrategy, dedupSelection) = GetMinimisationStrategy(settings.Minimise, ['F', 'Z']);
+            var (minimisationStrategy, dedupSelection) = GetMinimisationStrategy(settings.Minimise, [Letter.feedRate, 'Z']);
             var tokenDefsPath = CleanSettings.GetCleanTokenDefsPath(settings.TokenDefs);
             var (tokenDefinitions, _) = CleanSettings.LoadAndVerifyTokenDefs(tokenDefsPath);
 

--- a/CLI/Merge/MergeCommand.cs
+++ b/CLI/Merge/MergeCommand.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for details.
+
+using System.Diagnostics.CodeAnalysis;
+
+using GCodeClean.Processing;
+
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace GCodeCleanCLI.Merge
+{
+    public class MergeCommand : Command<MergeSettings> {
+        public override int Execute([NotNull] CommandContext context, [NotNull] MergeSettings settings) {
+            var inputFolder = settings.Foldername;
+            AnsiConsole.MarkupLine($"Inputting from folder: [bold green]{inputFolder}[/]");
+
+            inputFolder.MergeFile();
+
+            AnsiConsole.MarkupLine($"Merge completed");
+
+            return 0;
+        }
+    }
+}

--- a/CLI/Merge/MergeSettings.cs
+++ b/CLI/Merge/MergeSettings.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for details.
+
+using System.ComponentModel;
+
+using Spectre.Console.Cli;
+
+namespace GCodeCleanCLI.Merge
+{
+    public class MergeSettings : CommandSettings {
+        [CommandOption("-f|--foldername <FILENAME>")]
+        [Description("Full path to the input folder. This is the [italic]only[/] required option.")]
+        public string Foldername { get; set; }
+    }
+}

--- a/CLI/Program.cs
+++ b/CLI/Program.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) 2020-23 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+﻿// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System.Threading.Tasks;
 
 using GCodeCleanCLI.Clean;
+using GCodeCleanCLI.Merge;
 using GCodeCleanCLI.Split;
 
 using Spectre.Console.Cli;
@@ -23,6 +24,8 @@ namespace GCodeCleanCLI
                     .WithDescription("Clean your GCode file. This is the default command");
                 config.AddCommand<SplitCommand>("split")
                     .WithDescription("Split your GCode file into individual cutting actions");
+                config.AddCommand<MergeCommand>("merge")
+                    .WithDescription("Merge a folder of files, produced by split, back into a single GCode file");
             });
 
             if (args.Length == 0) {

--- a/CLI/Split/SplitCommand.cs
+++ b/CLI/Split/SplitCommand.cs
@@ -17,9 +17,10 @@ namespace GCodeCleanCLI.Split
         public static string DetermineOutputFoldername(SplitSettings options) {
             var inputFile = options.Filename;
 
+            var outputFolderPath = Path.GetDirectoryName(inputFile);
             var outputFolder = Path.GetFileNameWithoutExtension(inputFile);
 
-            return outputFolder;
+            return Path.Join(outputFolderPath, outputFolder);
         }
 
         public override int Execute([NotNull] CommandContext context, [NotNull] SplitSettings settings) {

--- a/CLI/Split/SplitCommand.cs
+++ b/CLI/Split/SplitCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System.Diagnostics.CodeAnalysis;
@@ -6,6 +6,7 @@ using System.IO;
 
 using GCodeClean.IO;
 using GCodeClean.Processing;
+
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/GCodeClean.Tests/Dedup.Tests.cs
+++ b/GCodeClean.Tests/Dedup.Tests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System;
@@ -14,15 +14,7 @@ using Xunit.Abstractions;
 
 namespace GCodeClean.Tests
 {
-    public class Dedup
-    {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public Dedup(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
-        }
-
+    public class Dedup(ITestOutputHelper testOutputHelper) {
         private static async IAsyncEnumerable<Line> AsyncLines(IEnumerable<Line> lines)
         {
             foreach (var line in lines)

--- a/GCodeClean.Tests/GCodeClean.Tests.csproj
+++ b/GCodeClean.Tests/GCodeClean.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.8.0.76515" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.15.0.81779" />
   </ItemGroup>
 
 </Project>

--- a/GCodeClean.Tests/Line.Tests.cs
+++ b/GCodeClean.Tests/Line.Tests.cs
@@ -8,13 +8,16 @@ using Xunit.Abstractions;
 
 namespace GCodeClean.Tests
 {
-    public class LineTest
-    {
-        private readonly ITestOutputHelper _testOutputHelper;
+    public class LineTest(ITestOutputHelper testOutputHelper) {
+        [Fact]
+        public void TestParseString() {
+            var sourceLine = "/  G01 N33 (Penetrate) X803.195 #54=-4 Y317.845 Z#54 (and Cut)";
+            var sourceTokenisedLine = new Line(sourceLine);
+            var expectedLine = "/ N33 G1 X803.195 #54=-4 Y317.845 Z#54 (Penetrate) (and Cut)";
 
-        public LineTest(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
+            var resultLine = sourceTokenisedLine.ToString();
+            Assert.False(sourceLine == resultLine);
+            Assert.True(expectedLine == resultLine);
         }
 
         [Fact]

--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -202,13 +202,13 @@ namespace GCodeClean.Tests
                 new Line("G21"),
                 new Line("G90"),
                 new Line("G1 Z0.15678 F9.0"),
-                new Line("G1234")
+                new Line("/G1234")
             ];
             List<string> expectedLines = [
                 "G21 (Length units: Millimeters)",
                 "G90 (Set Distance Mode: Absolute)",
                 "G1 Z0.1568 F9 (Linear motion: at Feed Rate, Z0.1568mm, Set Feed Rate to 9 {feedRateMode})",
-                "G1234"
+                "/ G1234 (Block Delete)"
             ];
 
 

--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -17,15 +17,7 @@ using Xunit.Abstractions;
 
 namespace GCodeClean.Tests
 {
-    public class Processing
-    {
-        private readonly ITestOutputHelper _testOutputHelper;
-
-        public Processing(ITestOutputHelper testOutputHelper)
-        {
-            _testOutputHelper = testOutputHelper;
-        }
-
+    public class Processing(ITestOutputHelper testOutputHelper) {
         private static async IAsyncEnumerable<Line> AsyncLines(IEnumerable<Line> lines)
         {
             foreach (var line in lines)
@@ -163,7 +155,7 @@ namespace GCodeClean.Tests
         [Fact]
         public async Task TestClip()
         {
-            List<Line> sourceLines =[
+            List<Line> sourceLines = [
                 new Line("G21"),
                 new Line("G90"),
                 new Line("G1 Z0.15678 F9.0")

--- a/GCodeClean/Processing/MergeFile.cs
+++ b/GCodeClean/Processing/MergeFile.cs
@@ -20,18 +20,19 @@ namespace GCodeClean.Processing
         /// </summary>
         /// <param name="inputLines"></param>
         /// <returns></returns>
-        public static List<(int id, Coord start, Coord end)> GetNodes(this string inputFolder) {
+        public static List<(string tool, int id, Coord start, Coord end)> GetNodes(this string inputFolder) {
             var fileEntries = Directory.GetFiles(inputFolder);
             Array.Sort(fileEntries);
-            List<(int id, Coord start, Coord end)> nodes = [];
+            List<(string tool, int id, Coord start, Coord end)> nodes = [];
             foreach (var filePath in fileEntries) {
                 string[] fileNameParts = Path.GetFileNameWithoutExtension(filePath).Split(separator);
-                var id = int.Parse(fileNameParts[0]);
-                var startCoords = fileNameParts[1].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
-                var endCoords = fileNameParts[2].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+                var tool = fileNameParts[0];
+                var id = int.Parse(fileNameParts[1]);
+                var startCoords = fileNameParts[2].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+                var endCoords = fileNameParts[3].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
                 var start = new Coord(startCoords[0], startCoords[1]);
                 var end = new Coord(endCoords[0], endCoords[1]);
-                nodes.Add((id, start, end));
+                nodes.Add((tool, id, start, end));
             }
 
             return nodes;
@@ -46,8 +47,8 @@ namespace GCodeClean.Processing
             var nodes = GetNodes(inputFolder);
             List<(int idA, int idB)> primaryPairs = [];
 
-            foreach (var (id, start, end) in nodes) {
-                var matchingNodes = nodes.FindAll(n => n.start.X == end.X && n.start.Y == end.Y);
+            foreach (var (tool, id, start, end) in nodes) {
+                var matchingNodes = nodes.FindAll(n => n.tool == tool && n.id != id && n.start.X == end.X && n.start.Y == end.Y);
                 if (matchingNodes.Count == 1) {
                     primaryPairs.Add((id, matchingNodes[0].id));
                 }

--- a/GCodeClean/Processing/MergeFile.cs
+++ b/GCodeClean/Processing/MergeFile.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for details.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using GCodeClean.Structure;
+
+using Spectre.Console;
+
+namespace GCodeClean.Processing
+{
+    public static partial class Merge {
+        private static readonly char[] separator = ['_'];
+
+        /// <summary>
+        /// Scan through the file for 'travelling' comments and build a list of them
+        /// </summary>
+        /// <param name="inputLines"></param>
+        /// <returns></returns>
+        public static List<(int id, Coord start, Coord end)> GetNodes(this string inputFolder) {
+            var fileEntries = Directory.GetFiles(inputFolder);
+            Array.Sort(fileEntries);
+            List<(int id, Coord start, Coord end)> nodes = [];
+            foreach (var filePath in fileEntries) {
+                string[] fileNameParts = Path.GetFileNameWithoutExtension(filePath).Split(separator);
+                var id = int.Parse(fileNameParts[0]);
+                var startCoords = fileNameParts[1].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+                var endCoords = fileNameParts[2].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+                var start = new Coord(startCoords[0], startCoords[1]);
+                var end = new Coord(endCoords[0], endCoords[1]);
+                nodes.Add((id, start, end));
+            }
+
+            return nodes;
+        }
+
+        public static void MergeFile(this string inputFolder) {
+            if (!Directory.Exists(inputFolder)) {
+                AnsiConsole.MarkupLine($"No such folder found. Nothing to see here, move along.");
+                return;
+            }
+
+            var nodes = GetNodes(inputFolder);
+            List<(int idA, int idB)> primaryPairs = [];
+
+            foreach (var (id, start, end) in nodes) {
+                var matchingNodes = nodes.FindAll(n => n.start.X == end.X && n.start.Y == end.Y);
+                if (matchingNodes.Count == 1) {
+                    primaryPairs.Add((id, matchingNodes[0].id));
+                }
+            }
+
+            foreach (var pair in primaryPairs) {
+                AnsiConsole.MarkupLine($"Node primary pairs: [bold yellow]{pair}[/]");
+            }
+            AnsiConsole.MarkupLine($"Count primary pairs: [bold yellow]{primaryPairs.Count}[/]");
+        }
+    }
+}

--- a/GCodeClean/Processing/Processing.cs
+++ b/GCodeClean/Processing/Processing.cs
@@ -531,7 +531,7 @@ namespace GCodeClean.Processing {
                             travellingLine = new Line(line);
                             travellingLine.ReplaceToken(new Token("G1"), new Token("G0"));
 
-                            line.AppendToken(new Token($"(||Travelling||{blockIx++}||>>{entryLine}>>{exitLine}>>||)"));
+                            line.AppendToken(new Token($"(||Travelling||{context.GetToolNumber()}||{blockIx++}||>>{entryLine}>>{exitLine}>>||)"));
                             entryLine = new Line();
                             entrySet = false;
                         }

--- a/GCodeClean/Processing/Processing.cs
+++ b/GCodeClean/Processing/Processing.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -122,10 +121,10 @@ namespace GCodeClean.Processing {
                         continue;
                     } else {
                         leadingBlankLinesStripped = true;
-                        hasLeadingFileTerminator = line.HasToken('%');
+                        hasLeadingFileTerminator = line.HasToken(Letter.fileTerminator);
                     }
                 } else {
-                    if (line.HasToken('%')) {
+                    if (line.HasToken(Letter.fileTerminator)) {
                         commentOutAllRemainingCommands = true;
                         if (!hasLeadingFileTerminator) {
                             // throw away the trailing terminator, because there is no leading one
@@ -578,7 +577,7 @@ namespace GCodeClean.Processing {
                         if (tokenDefs.TryGetProperty(subToken, out var subTokenDef)) {
                             annotation = subTokenDef.GetString();
                         }
-                        annotationContext[token.Code + "value"] = token.Number.Value.ToString(CultureInfo.InvariantCulture);
+                        annotationContext[token.Code + "value"] = $"{token.Number:0.####}";
                     } else {
                         tokenCodes.Add(token.ToString());
                     }

--- a/GCodeClean/Processing/Utility.cs
+++ b/GCodeClean/Processing/Utility.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System;
@@ -14,13 +14,11 @@ namespace GCodeClean.Processing
         /// <summary>
         /// Is B between A and C, inclusive
         /// </summary>
-        public static bool WithinRange(this decimal b, decimal a, decimal c)
-        {
+        public static bool WithinRange(this decimal b, decimal a, decimal c) {
             return a >= b && b >= c || a <= b && b <= c;
         }
 
-        public static double Angle(this double da, double db)
-        {
+        public static double Angle(this double da, double db) {
             var theta = Math.Atan2(da, db); // range (-PI, PI]
             theta *= 180 / Math.PI; // radians to degrees, range (-180, 180]
 
@@ -34,26 +32,22 @@ namespace GCodeClean.Processing
             return (decimal)theta;
         }
 
-        public static decimal Sqr(this decimal value)
-        {
+        public static decimal Sqr(this decimal value) {
             return value * value;
         }
 
-        public static decimal Distance(this (Coord A, Coord B) c)
-        {
+        public static decimal Distance(this (Coord A, Coord B) c) {
             return (decimal)Math.Sqrt((double)((c.B.X - c.A.X).Sqr() + (c.B.Y - c.A.Y).Sqr() + (c.B.Z - c.A.Z).Sqr()));
         }
 
         /// <summary>
         /// Get the number of decimal places in a decimal, ignoring any 'significant' zeros at the end
         /// </summary>
-        public static int GetDecimalPlaces(this decimal n)
-        {
+        public static int GetDecimalPlaces(this decimal n) {
             n = Math.Abs(n); //make sure it is positive.
             n -= (int)n;     //remove the integer part of the number.
             var decimalPlaces = 0;
-            while (n > 0)
-            {
+            while (n > 0) {
                 decimalPlaces++;
                 n *= 10;
                 n -= (int)n;
@@ -67,8 +61,7 @@ namespace GCodeClean.Processing
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public static string GetLengthUnits(this Context context)
-        {
+        public static string GetLengthUnits(this Context context) {
             var unitsCommand = context.GetModalState(ModalGroup.ModalUnits);
             return unitsCommand == null || unitsCommand.ToString() == "G20" ? "inch" : "mm";
         }
@@ -107,21 +100,15 @@ namespace GCodeClean.Processing
         public static decimal ConstrainTolerance(this decimal tolerance, string lengthUnits = "mm") {
             // Re-tweak tolerance to allow for lengthUnits
             if (lengthUnits == "mm") {
-                if (tolerance < 0.001M)
-                {
+                if (tolerance < 0.001M) {
                     tolerance = 0.001M;
-                }
-                else if (tolerance > 0.01M)
-                {
+                } else if (tolerance > 0.01M) {
                     tolerance = 0.01M;
                 }
             } else {
-                if (tolerance < 0.00005M)
-                {
+                if (tolerance < 0.00005M) {
                     tolerance = 0.00005M;
-                }
-                else if (tolerance > 0.2M)
-                {
+                } else if (tolerance > 0.2M) {
                     tolerance = 0.2M;
                 }
             }
@@ -137,47 +124,39 @@ namespace GCodeClean.Processing
         /// <param name="c"></param>
         /// <param name="coordPlane"></param>
         /// <returns></returns>
-        public static (Coord center, decimal radius, bool isClockwise) FindCircle(Coord a, Coord b, Coord c, string coordPlane)
-        {
+        public static (Coord center, decimal radius, bool isClockwise) FindCircle(Coord a, Coord b, Coord c, string coordPlane) {
             var center = new Coord();
             var radius = 0M;
             var isClockwise = false;
 
-            var ortho = coordPlane switch
-            {
+            var ortho = coordPlane switch {
                 "G17" => CoordSet.Z,
                 "G18" => CoordSet.Y,
                 "G19" => CoordSet.X,
                 _ => CoordSet.None,
             };
-            if (ortho == CoordSet.None)
-            {
+            if (ortho == CoordSet.None) {
                 ortho = Coord.Ortho([a, b, c]);
             }
-            if (ortho == CoordSet.None)
-            {
+            if (ortho == CoordSet.None) {
                 return (center, radius, isClockwise);
             }
 
             // Determine which coordinate we're dropping
             var dropCoord = CoordSet.Z;
-            if ((ortho & CoordSet.X) == CoordSet.X)
-            {
+            if ((ortho & CoordSet.X) == CoordSet.X) {
                 dropCoord = CoordSet.X;
             }
-            else if ((ortho & CoordSet.Y) == CoordSet.Y)
-            {
+            else if ((ortho & CoordSet.Y) == CoordSet.Y) {
                 dropCoord = CoordSet.Y;
             }
-            var droppedCoordOK = dropCoord switch
-            {
+            var droppedCoordOK = dropCoord switch {
                 CoordSet.Z => a.Z == b.Z && b.Z == c.Z,
                 CoordSet.Y => a.Y == b.Y && b.Y == c.Y,
                 CoordSet.X => a.X == b.X && b.X == c.X,
                 _ => false,
             };
-            if (!droppedCoordOK)
-            {
+            if (!droppedCoordOK) {
                 return (center, radius, isClockwise);
             }
 
@@ -219,8 +198,7 @@ namespace GCodeClean.Processing
                     + syBA * yAC)
                     / (2 * (xCA * yAB - xBA * yAC));
 
-            if (double.IsInfinity(f) || double.IsInfinity(g))
-            {
+            if (double.IsInfinity(f) || double.IsInfinity(g)) {
                 // lines are parallel / co-linear
                 return (center, radius, isClockwise);
             }
@@ -236,8 +214,7 @@ namespace GCodeClean.Processing
             var sqrOfR = h * h + k * k - circ;
 
             radius = (decimal)Math.Round(Math.Sqrt(sqrOfR), 5);
-            center = coordPlane switch
-            {
+            center = coordPlane switch {
                 "G17" => new Coord((decimal)h, (decimal)k, b.Z),
                 "G18" => new Coord((decimal)h, b.Y, (decimal)k),
                 "G19" => new Coord(b.X, (decimal)h, (decimal)k),
@@ -249,8 +226,7 @@ namespace GCodeClean.Processing
             return (center, radius, isClockwise);
         }
 
-        public static int DirectionOfPoint(PointF pA, PointF pB, PointF pC)
-        {
+        public static int DirectionOfPoint(PointF pA, PointF pB, PointF pC) {
             // subtracting co-ordinates of point A  
             // from B and P, to make A as origin
             pB.X -= pA.X;
@@ -262,58 +238,46 @@ namespace GCodeClean.Processing
             var crossProduct = pB.X * pC.Y - pB.Y * pC.X;
 
             // return the sign of the cross product 
-            if (crossProduct > 0)
-            {
+            if (crossProduct > 0) {
                 return 1;
             }
-            if (crossProduct < 0)
-            {
+            if (crossProduct < 0) {
                 return -1;
             }
             return 0;
         }
 
-        public static List<Coord> FindIntersections(Coord cA, Coord cB, decimal radius, string coordPlane)
-        {
+        public static List<Coord> FindIntersections(Coord cA, Coord cB, decimal radius, string coordPlane) {
             var intersections = new List<Coord>();
 
             // We only calculate a circle through one orthogonal plane,
             // therefore at least one of the dimensions must be the same for both coords
-            var ortho = coordPlane switch
-            {
+            var ortho = coordPlane switch {
                 "G17" => CoordSet.Z,
                 "G18" => CoordSet.Y,
                 "G19" => CoordSet.X,
                 _ => CoordSet.None,
             };
-            if (ortho == CoordSet.None)
-            {
-                ortho = Coord.Ortho(new List<Coord> { cA, cB });
+            if (ortho == CoordSet.None) {
+                ortho = Coord.Ortho([cA, cB]);
             }
-            if (ortho == CoordSet.None)
-            {
+            if (ortho == CoordSet.None) {
                 return intersections;
             }
 
             // Determine which coordinate we're dropping
             var dropCoord = CoordSet.Z;
-            if ((ortho & CoordSet.X) == CoordSet.X)
-            {
+            if ((ortho & CoordSet.X) == CoordSet.X) {
                 dropCoord = CoordSet.X;
-            }
-            else if ((ortho & CoordSet.Y) == CoordSet.Y)
-            {
+            } else if ((ortho & CoordSet.Y) == CoordSet.Y) {
                 dropCoord = CoordSet.Y;
             }
-            var droppedCoordOK = dropCoord switch
-            {
+            var droppedCoordOK = dropCoord switch {
                 CoordSet.Z => cA.Z == cB.Z,
                 CoordSet.Y => cA.Y == cB.Y,
-                CoordSet.X => cA.X == cB.X,
-                _ => false,
+                _ => cA.X == cB.X, // CoordSet.X
             };
-            if (!droppedCoordOK)
-            {
+            if (!droppedCoordOK) {
                 return intersections;
             }
 
@@ -328,8 +292,7 @@ namespace GCodeClean.Processing
 
             // See how many solutions there are.
             var tolerance = 0.000000001;
-            if (dist > (double)(radius * 2) || Math.Abs(dist) < tolerance)
-            {
+            if (dist > (double)(radius * 2) || Math.Abs(dist) < tolerance) {
                 // No solutions, the circles are too far apart or coincide, must be malformed
                 return intersections;
             }
@@ -347,8 +310,7 @@ namespace GCodeClean.Processing
                 (float)(pC.Y - h * (pB.X - pA.X) / dist)), dropCoord));
 
             // Do we have 1 or 2 solutions.
-            if (dist < (double)(radius * 2))
-            {
+            if (dist < (double)(radius * 2)) {
                 intersections.Add(new Coord(new PointF(
                 (float)(pC.X - h * (pB.Y - pA.Y) / dist),
                 (float)(pC.Y + h * (pB.X - pA.X) / dist)), dropCoord));

--- a/GCodeClean/Structure/Context.cs
+++ b/GCodeClean/Structure/Context.cs
@@ -78,6 +78,19 @@ namespace GCodeClean.Structure
             return null;
         }
 
+        public Token GetModalState(char code) {
+            foreach (var (line, _) in Lines) {
+                var lineTokens = line.Tokens.Where(t => t.Code == code);
+                if (!lineTokens.Any()) {
+                    continue;
+                }
+
+                return lineTokens.Last();
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Output all lines flagged as not yet output (isOutput == false)
         /// </summary>

--- a/GCodeClean/Structure/Context.cs
+++ b/GCodeClean/Structure/Context.cs
@@ -45,9 +45,9 @@ namespace GCodeClean.Structure
         /// <param name="isOutput"></param>
         public void Update(Line line, bool isOutput = false) {
             UpdateModal(line, isOutput, ModalGroup.ModalFeedRate);
-            UpdateModal(line, isOutput, 'F');
-            UpdateModal(line, isOutput, 'S');
-            UpdateModal(line, isOutput, 'T');
+            UpdateModal(line, isOutput, Letter.feedRate);
+            UpdateModal(line, isOutput, Letter.spindleSpeed);
+            UpdateModal(line, isOutput, Letter.selectTool);
             UpdateModal(line, isOutput, ModalGroup.ModalToolChange);
             UpdateModal(line, isOutput, ModalGroup.ModalSpindleTurning);
             // No support for Coolants in the context yet
@@ -62,7 +62,6 @@ namespace GCodeClean.Structure
             UpdateModal(line, isOutput, ModalGroup.ModalDistance);
             UpdateModal(line, isOutput, ModalGroup.ModalReturnMode);
             UpdateModal(line, isOutput, ModalGroup.ModalNon);
-            UpdateModal(line, isOutput, ModalGroup.ModalToolChange);
             UpdateModal(line, isOutput, ModalGroup.ModalCoolant);
         }
 

--- a/GCodeClean/Structure/Letter.cs
+++ b/GCodeClean/Structure/Letter.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com) and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for details.
+
+namespace GCodeClean.Structure
+{
+    public static class Letter
+    {
+        public static readonly char fileTerminator = '%';
+
+        /// <summary>
+        /// Marks the rest of the line as something to be 'ignored' if the "block delete" switch is on
+        /// </summary>
+        public static readonly char blockDelete = '/';
+
+        public static readonly char commentStart = '(';
+        public static readonly char commentEnd = ')';
+        public static readonly char commentSemi = ';';
+
+        public static readonly char gCommand = 'G';
+        public static readonly char mCommand = 'M';
+
+        public static readonly char feedRate = 'F';
+        public static readonly char spindleSpeed = 'S';
+        public static readonly char selectTool = 'T';
+
+        public static readonly char lineNumber = 'N';
+
+        public static readonly char[] FileTerminators = [fileTerminator];
+        public static readonly char[] BlockDeletes = [blockDelete];
+        public static readonly char[] Comments = [commentStart, commentSemi];
+        public static readonly char[] Commands = [gCommand, mCommand];
+        public static readonly char[] Codes = [feedRate, spindleSpeed, selectTool];
+        public static readonly char[] Arguments = ['A', 'B', 'C', 'D', 'H', 'I', 'J', 'K', 'L', 'P', 'R', 'X', 'Y', 'Z'];
+        public static readonly char[] LineNumbers = [lineNumber];
+        /// <summary>
+        /// Parameters are identified by a Hash followed by an integer (from 1 to 5399)
+        /// Parameters may be set (a command) or may be used as a value (after a command, code or argument)
+        /// </summary>
+        public static readonly char[] Parameters = ['#'];
+        public static readonly char[] Other = ['E', 'O', 'Q', 'U', 'V'];
+
+        public static readonly decimal[] GCodes = [
+            0, 1, 2, 3, 4, 10, 17, 18, 19, 20, 21, 28, 30, 38.2M,
+            40, 41, 42, 43, 49, 53, 54, 55, 56, 57, 58, 59, 59.1M, 59.2M, 59.3M,
+            61, 61.1M, 64, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89,
+            90, 91, 92, 92.1M, 92.2M, 92.3M, 93, 94, 98, 99
+        ];
+
+        public static readonly decimal[] MCodes = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 30, 48, 49, 60
+        ];
+    }
+}

--- a/GCodeClean/gcodeclean.csproj
+++ b/GCodeClean/gcodeclean.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />    
   </ItemGroup>
 
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.8.0.76515" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.15.0.81779" />
   </ItemGroup>  
 
 </Project>

--- a/GCodeClean/tokenDefinitions.json
+++ b/GCodeClean/tokenDefinitions.json
@@ -128,6 +128,7 @@
 		"M98": "Subprogram: Call",
 		"M99": "Subprogram: End",
 
+		"/": "Block Delete",
 		"#": "Set Parameter",
 
 		"D": "Tool Radius Compensation",

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ OPTIONS:
 
 Each individual file should be a valid GCode file that can be run independently.
 
-The name of these files will be made up of 3 parts, the index of the cutting path from the original file (starting at 0), the starting XY coordinate of the cutting path, and the finishing XY coordinate of the cutting path. Each part of the filename is delimited with an underscore `_`.
+The name of these files will be made up of 4 parts, the tool number, the index of the cutting path from the original file (starting at 0), the starting XY coordinate of the cutting path, and the finishing XY coordinate of the cutting path. Each part of the filename is delimited with an underscore `_`.
 
 ## What's Special about GCodeClean?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.2.1   | :white_check_mark: |
+| 1.2.2   | :white_check_mark: |
 
 ## Reporting a Vulnerability
 

--- a/gitAndMiss.cmd
+++ b/gitAndMiss.cmd
@@ -1,0 +1,4 @@
+@ECHO OFF
+@ECHO For when git is misbehaving
+git rm --cached -r .
+git reset .


### PR DESCRIPTION
# Description

Main reason for this :pr: is to fix a bug I introduced with v1.2.1 . This bug would break some but not all of the tests. And would likely lead to some bad output in the cleaned file.

The code clean up was a pass through to minimise the use of 'magic characters' throughout the code base, focussing on the starting letters of each GCode word.

Also added support for the 'block delete' character, which is a weird idea in the NIST spec that lets you selectively 'block' certain lines from being executed when a 'block delete' button is activated on your machine. Including adding a new test, and altering an existing one to check it out.