### PR TITLE
1.3.3 - Improved `merge`

### DIFF
--- a/CLI/Merge/MergeAction.cs
+++ b/CLI/Merge/MergeAction.cs
@@ -1,8 +1,9 @@
-// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2023-2024 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System;
 using System.IO;
+
 using GCodeClean.Merge;
 
 

--- a/CLI/Split/SplitAction.cs
+++ b/CLI/Split/SplitAction.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for details.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 using GCodeClean.IO;
 using GCodeClean.Shared;
@@ -30,6 +32,101 @@ namespace GCodeCleanCLI.Split
             var travellingComments = inputLines.GetTravellingComments();
             var preambleLines = inputLines.GetPreamble();
             var postambleLines = inputLines.GetPostamble(travellingComments[^1]);
+
+            List<(short seqId, short subSeqId, short nodeId, decimal max, string tool)> rawData = [];
+
+            travellingComments.ForEach(tc => {
+                var splitTC = tc.Replace("(||", "").Replace("||)", "").Split("||", StringSplitOptions.None);
+                rawData.Add((short.Parse(splitTC[1]), short.Parse(splitTC[2]), short.Parse(splitTC[3]), decimal.Parse(splitTC[4]), splitTC[5]));
+            });
+
+            // Get each sequence in order, we'll handle each of these discreetly
+            var sequences = rawData.Select(rd => rd.seqId).Distinct().ToList();
+
+            var rawDataMaxes = rawData.Select(rd => rd.max);
+            var depthCutMin = rawDataMaxes.Max();
+            var depthCutMax = rawDataMaxes.Min();
+            var depthCutRange = (depthCutMax - depthCutMin) / 10;
+            var depthCutRanges = Enumerable.Range(0, 10).Select(ix => (min: depthCutMin + (depthCutRange * ix), max: depthCutMin + (depthCutRange * (ix + 1)), cnt: 0)).ToList();
+
+            foreach (var sequence in sequences) {
+                var seqRawDataMaxes = rawData.Where(rd => rd.seqId == sequence).Select(rd => rd.max);
+
+                for (var ix = 0; ix < depthCutRanges.Count; ix++) {
+                    var dcr = depthCutRanges[ix];
+                    // Invert the max and min tests, because we're actually testing furtherest away from zero
+                    dcr.cnt = seqRawDataMaxes.Count(rd => rd > dcr.max && rd <= dcr.min);
+                    if (ix == depthCutRanges.Count - 1) {
+                        dcr.cnt += seqRawDataMaxes.Count(rd => rd == dcr.max);
+                    }
+                    depthCutRanges[ix] = dcr;
+                }
+
+                depthCutRanges = depthCutRanges.Where(dcr => dcr.cnt > 0).ToList();
+                if (depthCutRanges.Count > 1) {
+                    for (var ix = depthCutRanges.Count - 2; ix >= 0; ix--) {
+                        var dcr = depthCutRanges[ix];
+                        // If this particular depth cut range has only one entry, merge the next entry up into it
+                        // and remove the next entry
+                        if (dcr.cnt == 1) {
+                            dcr.cnt += depthCutRanges[ix + 1].cnt;
+                            dcr.max = depthCutRanges[ix + 1].max;
+                            depthCutRanges[ix] = dcr;
+                            depthCutRanges.RemoveAt(ix + 1);
+                            // If there's an entry before this one, and that entry has only a single value, then we'll skip over it
+                            if (ix > 0 && depthCutRanges[ix - 1].cnt == 1) {
+                                ix--;
+                            }
+                        }
+                    }
+                }
+
+                if (depthCutRanges.Count == 1) {
+                    // Only one sub sequence, so leave it as-is for each rawData value
+                    continue;
+                }
+
+                for (var ix = 0; ix < rawData.Count; ix++) {
+                    var rd = rawData[ix];
+                    if (rd.seqId != sequence) {
+                        continue;
+                    }
+                    for (short jx = 0; jx < depthCutRanges.Count; jx++) {
+                        var (min, max, _) = depthCutRanges[jx];
+                        if (rd.max > max && rd.max < min) {
+                            rd.subSeqId = jx;
+                            rawData[ix] = rd;
+                        }
+                        if (jx == depthCutRanges.Count - 1 && rd.max == max) {
+                            rd.subSeqId = jx;
+                            rawData[ix] = rd;
+                        }
+                    }
+                }
+            }
+
+
+            depthCutRanges = depthCutRanges.Where(dcr => dcr.cnt > 0).ToList();
+            if (depthCutRanges.Count > 1) {
+                for (var ix = depthCutRanges.Count - 2; ix >= 0; ix--) {
+                    var dcr = depthCutRanges[ix];
+                    // If this particular depth cut range has only one entry, merge the next entry up into it
+                    // and remove the next entry
+                    if (dcr.cnt == 1) {
+                        dcr.cnt += depthCutRanges[ix + 1].cnt;
+                        dcr.max = depthCutRanges[ix + 1].max;
+                        depthCutRanges[ix] = dcr;
+                        depthCutRanges.RemoveAt(ix + 1);
+                        // If there's an entry before this one, and that entry has only a single value, then we'll skip over it
+                        if (ix > 0 && depthCutRanges[ix - 1].cnt == 1) {
+                            ix--;
+                        }
+                    }
+                }
+            }
+            if (depthCutRanges.Count > 0) {
+                // Redo the sub sequence value in the travelling comments
+            }
 
             inputLines.SplitFile(outputFolder, travellingComments, preambleLines, postambleLines);
 

--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -249,18 +249,20 @@ namespace GCodeClean.Tests
             var sourceLineLines = sourceTextLines.ConvertAll(l => new Line(l));
             var sourceLines = sourceTextLines.ToAsyncEnumerable();
 
+            var zClamp = 1.5M;
+
             List<Line> expectedLines = [
                 new Line("G0 Z1.5"),
                 new Line("G0 X68.904 Y128.746 Z1.5"),
                 new Line("G1 X68.904 Y128.746 Z-1.194"),
                 new Line("G1 X68.995 Y128.814 Z-1.254"),
                 new Line("G1 X69.089 Y128.892 Z-1.322"),
-                new Line("G0 X69.089 Y128.892 Z1.5 (||Travelling||notset||0||>>G0 X68.904 Y128.746 Z1.5>>G0 X69.089 Y128.892 Z1.5>>||)"),
+                new Line("G0 X69.089 Y128.892 Z1.5 (||Travelling||notset||0||>>G0 X68.904 Y128.746 Z1.5>>G0 X69.089 Y128.892 Z1.5>>||-1.194||-1.257||-1.322||0.052||)"),
                 new Line("G0 X42.239 Y157.031 Z1.5"),
                 new Line("G1 X42.239 Y157.031 Z-0.413"),
             ];
 
-            var resultLines = await sourceLines.CleanLinesFirstPhase(false).DetectTravelling().ToListAsync();
+            var resultLines = await sourceLines.CleanLinesFirstPhase(false).DetectTravelling(zClamp).ToListAsync();
             Assert.False(sourceLineLines.SequenceEqual(resultLines));
             Assert.True(expectedLines.SequenceEqual(resultLines));
         }

--- a/GCodeClean.Tests/Processing.Tests.cs
+++ b/GCodeClean.Tests/Processing.Tests.cs
@@ -257,7 +257,7 @@ namespace GCodeClean.Tests
                 new Line("G1 X68.904 Y128.746 Z-1.194"),
                 new Line("G1 X68.995 Y128.814 Z-1.254"),
                 new Line("G1 X69.089 Y128.892 Z-1.322"),
-                new Line("G0 X69.089 Y128.892 Z1.5 (||Travelling||notset||0||>>G0 X68.904 Y128.746 Z1.5>>G0 X69.089 Y128.892 Z1.5>>||-1.194||-1.257||-1.322||0.052||)"),
+                new Line("G0 X69.089 Y128.892 Z1.5 (||Travelling||0||0||0||-1.322||notset||>>G0 X68.904 Y128.746 Z1.5>>G0 X69.089 Y128.892 Z1.5>>||)"),
                 new Line("G0 X42.239 Y157.031 Z1.5"),
                 new Line("G1 X42.239 Y157.031 Z-0.413"),
             ];

--- a/GCodeClean.Tests/Workflow.Tests.cs
+++ b/GCodeClean.Tests/Workflow.Tests.cs
@@ -167,12 +167,12 @@ namespace GCodeClean.Tests
                 new Line("G0 X54.178 Y136.211 Z0.5"),
                 new Line("G1 X54.178 Y136.211 Z-0.678"),
                 new Line("G1 X54.033 Y136.095 Z-0.499"),
-                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||-0.499||-0.597||-0.678||0.074||)"),
+                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||0||0||0||-0.678||notset||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||)"),
 
                 new Line("G0 X69.089 Y128.892 Z0.5"),
                 new Line("G1 X69.089 Y128.892 Z-0.661"),
                 new Line("G1 X68.813 Y128.684 Z-0.57"),
-                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||-0.57||-0.614||-0.661||0.034||)"),
+                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||0||0||1||-0.661||notset||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||)"),
 
                 new Line(Default.PostAmbleCompleted),
                 new Line("M30"),
@@ -263,12 +263,12 @@ namespace GCodeClean.Tests
                 new Line("G0 X54.178 Y136.211"),
                 new Line("G1 X54.178 Y136.211 Z-0.678"),
                 new Line("G1 X54.033 Y136.095 Z-0.499"),
-                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||-0.499||-0.597||-0.678||0.074||)"),
+                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||0||0||0||-0.678||notset||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||)"),
 
                 new Line("G0 X69.089 Y128.892"),
                 new Line("G1 X69.089 Y128.892 Z-0.661"),
                 new Line("G1 X68.813 Y128.684 Z-0.57"),
-                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||-0.57||-0.614||-0.661||0.034||)"),
+                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||0||0||1||-0.661||notset||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||)"),
 
                 new Line(Default.PostAmbleCompleted),
                 new Line("M30"),

--- a/GCodeClean.Tests/Workflow.Tests.cs
+++ b/GCodeClean.Tests/Workflow.Tests.cs
@@ -167,12 +167,12 @@ namespace GCodeClean.Tests
                 new Line("G0 X54.178 Y136.211 Z0.5"),
                 new Line("G1 X54.178 Y136.211 Z-0.678"),
                 new Line("G1 X54.033 Y136.095 Z-0.499"),
-                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||)"),
+                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||-0.499||-0.597||-0.678||0.074||)"),
 
                 new Line("G0 X69.089 Y128.892 Z0.5"),
                 new Line("G1 X69.089 Y128.892 Z-0.661"),
                 new Line("G1 X68.813 Y128.684 Z-0.57"),
-                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||)"),
+                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||-0.57||-0.614||-0.661||0.034||)"),
 
                 new Line(Default.PostAmbleCompleted),
                 new Line("M30"),
@@ -263,12 +263,12 @@ namespace GCodeClean.Tests
                 new Line("G0 X54.178 Y136.211"),
                 new Line("G1 X54.178 Y136.211 Z-0.678"),
                 new Line("G1 X54.033 Y136.095 Z-0.499"),
-                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||)"),
+                new Line("G0 X54.033 Y136.095 Z0.5 (||Travelling||notset||0||>>G0 X54.178 Y136.211 Z0.5>>G0 X54.033 Y136.095 Z0.5>>||-0.499||-0.597||-0.678||0.074||)"),
 
                 new Line("G0 X69.089 Y128.892"),
                 new Line("G1 X69.089 Y128.892 Z-0.661"),
                 new Line("G1 X68.813 Y128.684 Z-0.57"),
-                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||)"),
+                new Line("G0 X68.813 Y128.684 Z0.5 (||Travelling||notset||1||>>G0 X69.089 Y128.892 Z0.5>>G0 X68.813 Y128.684 Z0.5>>||-0.57||-0.614||-0.661||0.034||)"),
 
                 new Line(Default.PostAmbleCompleted),
                 new Line("M30"),

--- a/GCodeClean/Merge/Algorithm.cs
+++ b/GCodeClean/Merge/Algorithm.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2023-2024 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the AGPL license. See LICENSE.txt file in the project root for details.
 
 using System;
@@ -336,7 +336,7 @@ namespace GCodeClean.Merge
                 unpairedPrevNodes = pairedEdges.UnpairedPrevNodes(nodes);
             }
 
-            // Make a final decision about rotating the whole list
+            // Make a decision about rotating the whole list
             var firstNode = nodes.GetNode(pairedEdges[0].PrevId);
             var lastNode = nodes.GetNode(pairedEdges[^1].NextId);
             var maxEdge = pairedEdges.OrderByDescending(pe => pe.Distance).FirstOrDefault();

--- a/GCodeClean/Merge/Algorithm.cs
+++ b/GCodeClean/Merge/Algorithm.cs
@@ -22,8 +22,8 @@ namespace GCodeClean.Merge
             Console.WriteLine("Pass 0: Primary Edges");
 
             List<Edge> primaryEdges = [];
-            foreach (var (tool, id, start, end) in nodes) {
-                var matchingNodes = nodes.FindAll(n => n.Tool == tool && n.Id != id && n.Start.X == end.X && n.Start.Y == end.Y);
+            foreach (var (seq, subSeq, id, maxZ, tool, start, end) in nodes) {
+                var matchingNodes = nodes.FindAll(n => n.Seq == seq && n.SubSeq == subSeq && n.Tool == tool && n.Id != id && n.Start.X == end.X && n.Start.Y == end.Y);
                 if (matchingNodes.Count > 1) {
                     // This may be some kind of 'peck-drilling' operation, whatever it is
                     // simply take the first node

--- a/GCodeClean/Merge/MergeFile.cs
+++ b/GCodeClean/Merge/MergeFile.cs
@@ -1,8 +1,11 @@
-// Copyright (c) 2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2023-2024 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the AGPL license. See LICENSE.txt file in the project root for details.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+
+using GCodeClean.Processing;
 
 
 namespace GCodeClean.Merge
@@ -18,12 +21,6 @@ namespace GCodeClean.Merge
             }
 
             var nodes = inputFolder.GetNodes().ToList();
-            var tools = nodes.Select(n => n.Tool).Distinct().ToList();
-
-            if (tools.Count > 1) {
-                Console.WriteLine("Currently only one tool per merge is supported");
-                return;
-            }
 
             //AnsiConsole.MarkupLine($"Nodes:");
             //foreach (var node in nodes.Select(n => (n.Id, n.Start, n.End))) {
@@ -32,7 +29,28 @@ namespace GCodeClean.Merge
 
             var currentDistance = nodes.TotalDistance(nodes.Select(n => n.Id).ToList());
 
-            var pairedEdges = nodes.TravellingReorder();
+            List<Edge> pairedEdges = [];
+
+            foreach (var (seq, subSeq) in nodes.Select(n => (n.Seq, n.SubSeq)).Distinct()) {
+                var subSeqNodes = nodes.Where(n => n.Seq == seq && n.SubSeq == subSeq).ToList();
+                if (subSeqNodes.Count > 1) {
+                    var subSeqEdges = subSeqNodes.TravellingReorder();
+                    if (pairedEdges.Count > 0) {
+                        var lastPairedNode = nodes.GetNode(pairedEdges[^1].NextId);
+                        var firstSubSeqNode = nodes.GetNode(subSeqEdges[0].PrevId);
+                        var joiningEdge = new Edge(lastPairedNode.Id, firstSubSeqNode.Id, (lastPairedNode.End, firstSubSeqNode.Start).Distance(), pairedEdges[^1].Weighting);
+                        pairedEdges.Add(joiningEdge);
+                    }
+                    pairedEdges.AddRange(subSeqEdges);
+                } else {
+                    if (pairedEdges.Count > 0) {
+                        var lastPairedNode = nodes.GetNode(pairedEdges[^1].NextId);
+                        var firstSubSeqNode = subSeqNodes[0];
+                        var joiningEdge = new Edge(lastPairedNode.Id, firstSubSeqNode.Id, (lastPairedNode.End, firstSubSeqNode.Start).Distance(), pairedEdges[^1].Weighting);
+                        pairedEdges.Add(joiningEdge);
+                    }
+                }
+            }
 
             //AnsiConsole.MarkupLine($"Pairings that were good:");
             //foreach (var pair in pairedEdges.Select(tps => (tps.PrevId, tps.NextId, tps.Distance, tps.Weighting))) {
@@ -41,7 +59,7 @@ namespace GCodeClean.Merge
             var nodeIdList = pairedEdges.GetNodeIds();
             var newDistance = nodes.TotalDistance(nodeIdList);
 
-            Console.WriteLine($"Total distinct tools: {tools.Count}");
+            Console.WriteLine($"Total distinct tools: {nodes.Select(n => n.Tool).Distinct().Count()}");
             Console.WriteLine($"Total nodes: {nodes.Count}");
             Console.WriteLine($"Total edges: {pairedEdges.Count}");
 

--- a/GCodeClean/Merge/NodeFileIO.cs
+++ b/GCodeClean/Merge/NodeFileIO.cs
@@ -35,13 +35,19 @@ namespace GCodeClean.Merge
             List<Node> nodes = [];
             foreach (var filePath in fileEntries) {
                 var fileNameParts = Path.GetFileNameWithoutExtension(filePath).Split(separator);
-                var tool = fileNameParts[0];
-                var id = Int16.Parse(fileNameParts[1]);
-                var startCoords = fileNameParts[2].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
-                var endCoords = fileNameParts[3].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+
+                var seq = short.Parse(fileNameParts[0]);
+                var subSeq = short.Parse(fileNameParts[1]);
+                var id = short.Parse(fileNameParts[2]);
+                var maxZ = decimal.Parse(fileNameParts[3]);
+                var tool = fileNameParts[4];
+
+                var startCoords = fileNameParts[5].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
+                var endCoords = fileNameParts[6].Replace("X", "").Split("Y").Select(c => decimal.Parse(c)).ToArray();
                 var start = new Coord(startCoords[0], startCoords[1]);
                 var end = new Coord(endCoords[0], endCoords[1]);
-                nodes.Add(new Node(tool, id, start, end));
+
+                nodes.Add(new Node(seq, subSeq, id, maxZ, tool, start, end));
             }
 
             return nodes;

--- a/GCodeClean/Processing/Default.cs
+++ b/GCodeClean/Processing/Default.cs
@@ -1,7 +1,5 @@
-// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2020-2024 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the AGPL license. See LICENSE.txt file in the project root for details.
-
-using System.Collections.Generic;
 
 using GCodeClean.Structure;
 
@@ -15,8 +13,7 @@ namespace GCodeClean.Processing
         public static Context Preamble()
         {
             var context = new Context(
-                new List<(Line line, bool isOutput)>
-                {
+                [
                     (new Line("G21"), false), // Length units, mm - alternate G20
                     (new Line("G90"), false), // Distance mode, absolute - alternate G91
                     (new Line("G94"), false), // Feed mode, per minute - alternate G93
@@ -33,7 +30,7 @@ namespace GCodeClean.Processing
                     // (new Line("G4 P2"), false), // Dwell, for 2 seconds - useful before any S command to allow the spindle to speed up
                     // (new Line("S"), false), // Spindle speed
                     // (new Line("M7 M8"), false), // Coolant control, mist and flood - alternates are any one of M7, M8, M9 
-                }
+                ]
             );
 
             return context;
@@ -45,8 +42,7 @@ namespace GCodeClean.Processing
         /// <returns></returns>
         public static Context Postamble() {
             var context = new Context(
-                new List<(Line line, bool isOutput)>
-                {
+                [
                     (new Line("Z10"), false), // Raise the tool - this will need to be zClamped
                     (new Line("G30"), false), // Return to home - alternate G28
                     // The following should all be performed as a part of M2 or M30
@@ -61,7 +57,7 @@ namespace GCodeClean.Processing
                     //(new Line("G1"), false), // Linear motion: at Feed Rate
                     //(new Line("M9"), false), // Coolant: Mist and Flood, Off
                     (new Line("M2"), false), // Program stop, alternates M0, M1, M30, M60
-                }
+                ]
             );
 
             return context;

--- a/GCodeClean/Processing/Linter.cs
+++ b/GCodeClean/Processing/Linter.cs
@@ -125,8 +125,8 @@ namespace GCodeClean.Processing {
                     currentLine.AllTokens = yieldableLines[0].AllTokens.Concat(currentLine.Tokens).ToList();
                 }
 
-                // Motion commands without arguments are invalid (and should be discarded)
-                if (currentLine.Tokens.Count == 1 && ModalGroup.ModalSimpleMotion.Contains(currentLine.Tokens[0])) {
+                // Motion commands (simple and probe) without arguments are invalid (and should be discarded)
+                if (currentLine.Tokens.Count == 1 && (ModalGroup.ModalSimpleMotion.Contains(currentLine.Tokens[0]) || ModalGroup.ModalProbeMotion.Contains(currentLine.Tokens[0]))) {
                     currentLine.ClearTokens();
                 }
 

--- a/GCodeClean/Processing/Processing.cs
+++ b/GCodeClean/Processing/Processing.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
@@ -301,17 +302,27 @@ namespace GCodeClean.Processing {
 
                 if (hasZ && hasTravelling) {
                     var zToken = line.AllTokens.First(t => t.Code == 'Z');
+                    var currZ = zToken.Number.Value;
 
                     var travelingToken = line.AllTokens.Intersect(ModalGroup.ModalSimpleMotion).First();
+                    var hasLinearTravelling = line.HasTokens(["G0", "G1"]);
+                    var coordPlane = context.GetCoordPlane();
+                    var isXYPlane = coordPlane == "G17" || coordPlane == "";
 
                     if (zToken.Number > 0) {
-                        // If Z > 0 then the z value should be constrained
-                        zToken.Number = zClampConstrained;
-                        var xUnchanged = !hasX || line.AllTokens.First(t => t.Code == 'X').Number.Value == prevX;
-                        var yUnchanged = !hasY || line.AllTokens.First(t => t.Code == 'Y').Number.Value == prevY;
-                        if (prevZ > 0 || (xUnchanged || yUnchanged)) {
-                            // If the previous Z value is also > 0 or there's no X or Y movement then the motion should be G0
-                            travelingToken.Source = "G0";
+                        if (!isXYPlane && !hasLinearTravelling) {
+                            // Weird stuff - non XY Plane, and an arc
+                            // Emit a G1 to move back to the previous unclamped Z value
+                            yield return new Line($"G1 X{prevX} Y{prevY} Z{prevZ} (non XY plane curved cut starting point)");
+                        } else {
+                            // If Z > 0 then the z value should be constrained
+                            zToken.Number = zClampConstrained;
+                            var xUnchanged = !hasX || line.AllTokens.First(t => t.Code == 'X').Number.Value == prevX;
+                            var yUnchanged = !hasY || line.AllTokens.First(t => t.Code == 'Y').Number.Value == prevY;
+                            if (prevZ > 0 || (xUnchanged || yUnchanged)) {
+                                // If the previous Z value is also > 0 or there's no X or Y movement then the motion should be G0
+                                travelingToken.Source = "G0";
+                            }
                         }
                     } else if (zToken.Number == 0 && travelingToken.ToString() == "G1") {
                         // If Z == 0 and the source is G1, then we want to leave it alone as a surface exit from a cut
@@ -322,7 +333,7 @@ namespace GCodeClean.Processing {
 
                     prevX = hasX ? line.AllTokens.First(t => t.Code == 'X').Number.Value : prevX;
                     prevY = hasY ? line.AllTokens.First(t => t.Code == 'Y').Number.Value : prevY;
-                    prevZ = zToken.Number.Value;
+                    prevZ = currZ;
                 }
 
                 yield return line;
@@ -511,27 +522,48 @@ namespace GCodeClean.Processing {
         /// </summary>
         /// <param name="tokenisedLines"></param>
         /// <returns></returns>
-        public static async IAsyncEnumerable<Line> DetectTravelling(this IAsyncEnumerable<Line> tokenisedLines) {
+        public static async IAsyncEnumerable<Line> DetectTravelling(
+            this IAsyncEnumerable<Line> tokenisedLines,
+            decimal zClamp = 10.0M
+        ) {
             var context = Default.Preamble();
             var isTravelling = true; // Assuming that things start with +ve z-axis value
             var entryLine = new Line();
             var exitLine = new Line();
             var entrySet = false;
+            decimal? entryX = null;
+            decimal? entryY = null;
+            var seqIx = 0;
+            var currentTool = "";
             var blockIx = 0;
-            Line travellingLine;
+            List<decimal> allNegZeds = [];
+
+            var zClampConstrained = Utility.ConstrictZClamp(context.GetLengthUnits(), zClamp);
+            var zToken = new Token($"Z{zClampConstrained}");
 
             await foreach (var line in tokenisedLines) {
                 context.Update(line);
 
-                if (line.HasToken('X') || line.HasToken('Y')) {
+                var hasX = line.HasToken('X');
+                var hasY = line.HasToken('Y');
+                var hasZ = line.HasToken('Z');
+
+                if (hasX && !entryX.HasValue) {
+                    entryX = line.AllTokens.First(t => t.Code == 'X').Number.Value;
+                }
+                if (hasX && !entryY.HasValue) {
+                    entryY = line.AllTokens.First(t => t.Code == 'Y').Number.Value;
+                }
+
+                if (hasX || hasY) {
                     if (!entrySet) {
                         var possibleEntryLine = new Line(line);
                         if (possibleEntryLine.HasToken('Z')) {
-                            var zToken = possibleEntryLine.AllTokens.First(t => t.Code == 'Z');
-                            // Determine if the possible entryLine is actually a cutting line
-                            // and change accordingly
-                            entryLine = (zToken.Number > 0) ? possibleEntryLine : new Line(exitLine);
+                            zToken = possibleEntryLine.AllTokens.First(t => t.Code == 'Z');
                         }
+                        // Determine if the possible entryLine is actually a cutting line
+                        // and change accordingly
+                        entryLine = (zToken.Number > 0) ? possibleEntryLine : new Line(exitLine);
                         entrySet = true;
                     }
                     exitLine = new Line(line);
@@ -546,15 +578,31 @@ namespace GCodeClean.Processing {
                     }
                 }
 
-                if (line.HasToken('Z')) {
-                    var zToken = line.AllTokens.First(t => t.Code == 'Z');
+                if (hasZ) {
+                    zToken = line.AllTokens.First(t => t.Code == 'Z');
                     if (zToken.Number > 0) {
                         if (!isTravelling) {
-                            travellingLine = new Line(line);
-                            travellingLine.ReplaceToken(new Token("G1"), new Token("G0"));
+                            if (currentTool == "") {
+                                currentTool = context.GetToolNumber();
+                            } else if (currentTool != context.GetToolNumber()) {
+                                currentTool = context.GetToolNumber();
+                                seqIx++;
+                            }
+
+                            // The sub sequence index we'll determine with the `split` command
+                            var subSeqIx = 0;
+
+                            // This is the furtherest -ve number from zero - 'max' for our purposes
+                            var zMax = $"{allNegZeds.Min():0.###}";
+
+                            if (entryLine.AllTokens.Count == 0) {
+#pragma warning disable S3655
+                                entryLine = new Line($"G0 X{entryX.Value} Y{entryY.Value} {zToken}");
+#pragma warning restore S3655
+                            }
 
                             // Replace any existing travelling comment
-                            var travellingComment = new Token($"(||Travelling||{context.GetToolNumber()}||{blockIx++}||>>{entryLine}>>{exitLine}>>||)");
+                            var travellingComment = new Token($"(||Travelling||{seqIx}||{subSeqIx}||{blockIx++}||{zMax}||{currentTool}||>>{entryLine}>>{exitLine}>>||)");
                             var comments = line.AllCommentTokens;
                             if (comments.Count > 0) {
                                 for (var ix = 0; ix < comments.Count; ix++) {
@@ -565,6 +613,7 @@ namespace GCodeClean.Processing {
                                 }
                             } else {
                                 line.AppendToken(travellingComment);
+                                allNegZeds.Clear();
                             }
 
                             entryLine = new Line();
@@ -575,6 +624,7 @@ namespace GCodeClean.Processing {
                             isTravelling = true;
                         }
                     } else {
+                        allNegZeds.Add((decimal)zToken.Number);
                         isTravelling = false;
                     }
                 }

--- a/GCodeClean/Processing/Utility.cs
+++ b/GCodeClean/Processing/Utility.cs
@@ -97,12 +97,28 @@ namespace GCodeClean.Processing
         }
 
         /// <summary>
-        /// Get the length units from the context
+        /// Get the coordinate plane ("G17", "G18", "G19", "") from the context
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
         public static string GetCoordPlane(this Context context) {
-            return context.GetModalState(ModalGroup.ModalPlane).ToString();
+            var coordPlane = context.GetModalState(ModalGroup.ModalPlane);
+            return coordPlane != null ? coordPlane.ToString() : "";
+        }
+
+        /// <summary>
+        /// Get the standard deviation for the supplied list of decimal values
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static decimal StdDev(this List<decimal> values) {
+            if (values.Count <= 1) {
+                return 0;
+            }
+            var average = (double)values.Average();
+            var sumOfDerivationAverage = (double)values.Select(v => v * v).Sum() / values.Count;
+            var result = Math.Sqrt(sumOfDerivationAverage - (average * average));
+            return decimal.CreateTruncating(result);
         }
 
         public static decimal ConstrictZClamp(string lengthUnits = "mm", decimal zClamp = 10.0M) {

--- a/GCodeClean/Processing/Workflow.cs
+++ b/GCodeClean/Processing/Workflow.cs
@@ -123,7 +123,7 @@ namespace GCodeClean.Processing
                 .Clip(tolerance)
                 .DedupRepeatedTokens()
                 .DedupLine()
-                .DetectTravelling()
+                .DetectTravelling(zClamp)
                 .DedupLinear(tolerance);
 
             await foreach (var line in secondPhaseLines) {

--- a/GCodeClean/Shared/Structure.cs
+++ b/GCodeClean/Shared/Structure.cs
@@ -7,5 +7,5 @@ using GCodeClean.Structure;
 
 namespace GCodeClean.Shared
 {
-    public readonly record struct Node(string Tool, short Id, Coord Start, Coord End);
+    public readonly record struct Node(short Seq, short SubSeq, short Id, decimal MaxZ, string Tool, Coord Start, Coord End);
 }

--- a/GCodeClean/Shared/Utility.cs
+++ b/GCodeClean/Shared/Utility.cs
@@ -16,7 +16,7 @@ namespace GCodeClean.Shared
         /// <summary>
         /// Finds GCodeClean's special 'Travelling' comments
         /// </summary>
-        [GeneratedRegex("\\(\\|{2}Travelling\\|{2}.*\\|{2}\\d+\\|{2}>>G\\d+.*>>G\\d+.*>>\\|{2}\\)$")]
+        [GeneratedRegex("\\(\\|{2}Travelling(\\|{2}\\d+){3}\\|{2}\\-?\\d+.*\\|{2}.*\\|{2}>>G\\d+.*>>G\\d+.*>>\\|{2}\\)$")]
         private static partial Regex RegexTravellingPattern();
 
         /// <summary>
@@ -96,15 +96,18 @@ namespace GCodeClean.Shared
             return $"{folderName}{Path.DirectorySeparatorChar}{node.Tool}_{node.Id.ToString(idFtm)}_{node.Start.ToXYCoord()}_{node.End.ToXYCoord()}_gcc.nc";
         }
 
-        public static Node ParseTravelling(this string travelling) {
+        public static Node ToNode(this string travelling) {
             var tDetails = travelling.Replace("(||Travelling||", "").Replace("||)", "").Split("||");
-            var tTool = tDetails[0];
-            var tId = Convert.ToInt16(tDetails[1]);
-            var tSE = tDetails[2].Split(">>", StringSplitOptions.RemoveEmptyEntries);
+            var tSeq = short.Parse(tDetails[0]);
+            var tSubSeq = short.Parse(tDetails[1]);
+            var tId = short.Parse(tDetails[2]);
+            var tMaxZ = decimal.Parse(tDetails[3]);
+            var tTool = tDetails[4];
+            var tSE = tDetails[5].Split(">>", StringSplitOptions.RemoveEmptyEntries);
             var lStart = new Line(tSE[0]);
             var lEnd = new Line(tSE[1]);
 
-            return new Node(tTool, tId, (Coord)lStart, (Coord)lEnd);
+            return new Node(tSeq, tSubSeq, tId, tMaxZ, tTool, (Coord)lStart, (Coord)lEnd);
         }
     }
 }

--- a/GCodeClean/Shared/Utility.cs
+++ b/GCodeClean/Shared/Utility.cs
@@ -92,8 +92,11 @@ namespace GCodeClean.Shared
 
         public static string IdFormat(this int idCount) => $"D{idCount.ToString().Length}";
 
-        public static string NodeFileName(this Node node, string folderName, string idFtm) {
-            return $"{folderName}{Path.DirectorySeparatorChar}{node.Tool}_{node.Id.ToString(idFtm)}_{node.Start.ToXYCoord()}_{node.End.ToXYCoord()}_gcc.nc";
+        public static string NodeFileName(this Node node, string folderName, int[] idCounts) {
+            var seqFtm = idCounts[0].IdFormat();
+            var subSeqFtm = idCounts[1].IdFormat();
+            var idFtm = idCounts[2].IdFormat();
+            return $"{folderName}{Path.DirectorySeparatorChar}{node.Seq.ToString(seqFtm)}_{node.SubSeq.ToString(subSeqFtm)}_{node.Id.ToString(idFtm)}_{node.Tool}_{node.Start.ToXYCoord()}_{node.End.ToXYCoord()}_gcc.nc";
         }
 
         public static Node ToNode(this string travelling) {
@@ -109,5 +112,19 @@ namespace GCodeClean.Shared
 
             return new Node(tSeq, tSubSeq, tId, tMaxZ, tTool, (Coord)lStart, (Coord)lEnd);
         }
+
+        public static string ToTravelling(this Node node) {
+            var entryLine = $"G0 {node.Start.ToString()}";
+            var exitLine = $"G0 {node.End.ToString()}";
+            return $"(||Travelling||{node.Seq}||{node.SubSeq}||{node.Id}||{node.MaxZ:0.###}||{node.Tool}||>>{entryLine}>>{exitLine}>>||)";
+        }
+
+        /// <summary>
+        /// Copy the node, but set its SubSeq value to the supplied value
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="subSeq"></param>
+        /// <returns></returns>
+        public static Node CopySetSub(this Node node, short subSeq) => new(node.Seq, subSeq, node.Id, node.MaxZ, node.Tool, node.Start, node.End);
     }
 }

--- a/GCodeClean/Split/KMeans.cs
+++ b/GCodeClean/Split/KMeans.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GCodeClean.Split {
+    public static class KMeans {
+        public static int[] Cluster(this List<List<decimal>> rawData, int numClusters) {
+            // k-means clustering
+            // index of return is tuple ID, cell is cluster ID
+            // ex: [2 1 0 0 2 2] means tuple 0 is cluster 2, tuple 1 is cluster 1, tuple 2 is cluster 0, tuple 3 is cluster 0, etc.
+            // an alternative clustering DS to save space is to use the .NET BitArray class
+            var data = rawData.Normalised(); // so large values don't dominate
+
+            bool changed = true; // was there a change in at least one cluster assignment?
+            bool success = true; // were all means able to be computed? (no zero-count clusters)
+
+            // init clustering[] to get things started
+            int[] clustering = InitClustering(data.Count, numClusters, 0); // semi-random initialization
+            var means = Allocate(numClusters, data[0].Count); // small convenience
+
+            int maxCount = data.Count * 10; // sanity check
+            int ct = 0;
+            while (changed && success && ct < maxCount) {
+                ct++;
+                success = UpdateMeans(data, clustering, means);
+                changed = UpdateClustering(data, clustering, means);
+            }
+            return clustering;
+        }
+
+        private static List<List<decimal>> Normalised(this List<List<decimal>> rawData) {
+            // normalize raw data by computing (x - mean) / stddev
+            // primary alternative is min-max:
+            // v' = (v - min) / (max - min)
+
+            // make a copy of input data
+            var result = rawData.Select(rd => rd.Select(r => r).ToList()).ToList();
+
+            for (var jx = 0; jx < result[0].Count; jx++) {
+                // each col
+                var colSum = 0.0M;
+                for (var ix = 0; ix < result.Count; ix++) {
+                    colSum += result[ix][jx];
+                }
+
+                var mean = colSum / result.Count;
+                var sum = 0.0M;
+                for (var ix = 0; ix < result.Count; ix++) {
+                    var subMean = result[ix][jx] - mean;
+                    sum += (subMean * subMean);
+                }
+
+                var sd = sum / result.Count;
+                for (var ix = 0; ix < result.Count; ix++) {
+                    result[ix][jx] = (result[ix][jx] - mean) / sd;
+                }
+            }
+
+            return result;
+        }
+
+        private static int[] InitClustering(int numTuples, int numClusters, int randomSeed) {
+            // init clustering semi-randomly (at least one tuple in each cluster)
+            Random random = new Random(randomSeed);
+            var clustering = new int[numTuples];
+            for (var ix = 0; ix < numClusters; ix++) {
+                // make sure each cluster has at least one tuple
+                clustering[ix] = ix;
+            }
+            for (var ix = numClusters; ix < clustering.Length; ix++) {
+                clustering[ix] = random.Next(0, numClusters); // other assignments random
+            }
+
+            return clustering;
+        }
+
+        private static List<List<decimal>> Allocate(int numClusters, int numColumns) {
+            // convenience matrix allocator for Cluster()
+            var result = new List<List<decimal>>();
+            for (var ix = 0; ix < numClusters; ix++) {
+                var res = new List<decimal>(numColumns);
+                for (var jx = 0; jx < numColumns; jx++) {
+                    res.Add(0);
+                }
+                result.Add(res);
+            }
+            return result;
+        }
+
+        private static bool UpdateMeans(List<List<decimal>> data, int[] clustering, List<List<decimal>> means) {
+            // returns false if there is a cluster that has no tuples assigned to it
+
+            // check existing cluster counts
+            // can omit this check if InitClustering and UpdateClustering
+            // both guarantee at least one tuple in each cluster (usually true)
+            var numClusters = means.Count;
+            var clusterCounts = new int[numClusters];
+            for (var ix = 0; ix < data.Count; ix++) {
+                var cluster = clustering[ix];
+                clusterCounts[cluster]++;
+            }
+
+            for (var kx = 0; kx < numClusters; kx++) {
+                if (clusterCounts[kx] == 0) {
+                    return false; // bad clustering. no change to means
+                }
+            }
+
+            // update, zero-out means so it can be used as scratch matrix 
+            for (var kx = 0; kx < means.Count; kx++) {
+                for (var jx = 0; jx < means[kx].Count; jx++) {
+                    means[kx][jx] = 0.0M;
+                }
+            }
+
+            for (var ix = 0; ix < data.Count; ix++) {
+                var cluster = clustering[ix];
+                for (var jx = 0; jx < data[ix].Count; jx++) {
+                    means[cluster][jx] += data[ix][jx]; // accumulate sum
+                }
+            }
+
+            for (var kx = 0; kx < means.Count; kx++) {
+                for (var jx = 0; jx < means[kx].Count; jx++) {
+                    means[kx][jx] /= clusterCounts[kx]; // danger of div by 0
+                }
+            }
+
+            return true;
+        }
+
+        private static bool UpdateClustering(List<List<decimal>> data, int[] clustering, List<List<decimal>> means) {
+            // (re)assign each tuple to a cluster (closest mean)
+            // returns false if no tuple assignments change OR
+            // if the reassignment would result in a clustering where
+            // one or more clusters have no tuples.
+
+            var numClusters = means.Count;
+            var changed = false;
+
+            var newClustering = new int[clustering.Length]; // proposed result
+            Array.Copy(clustering, newClustering, clustering.Length);
+
+            var distances = new List<decimal>(numClusters); // distances from curr tuple to each mean
+
+            for (var ix = 0; ix < data.Count; ix++) // walk thru each tuple
+            {
+                for (var kx = 0; kx < numClusters; kx++) { 
+                    distances[kx] = Distance(data[ix], means[kx]); // compute distances from curr tuple to all k means
+                }
+
+                var newClusterID = distances.MinIndex(); // find closest mean ID
+                if (newClusterID != newClustering[ix]) {
+                    changed = true;
+                    newClustering[ix] = newClusterID; // update
+                }
+            }
+
+            if (!changed) { 
+                return false; // no change so bail and don't update clustering
+            }
+   
+            // check proposed clustering[] cluster counts
+            var clusterCounts = new int[numClusters];
+            for (var ix = 0; ix < data.Count; ix++) {
+                var cluster = newClustering[ix];
+                clusterCounts[cluster]++;
+            }
+
+            for (var kx = 0; kx < numClusters; kx++) {
+                if (clusterCounts[kx] == 0) {
+                    return false; // bad clustering. no change to clustering
+                }
+            }
+
+            Array.Copy(newClustering, clustering, newClustering.Length); // update
+            return true; // good clustering and at least one change
+        }
+
+        private static decimal Distance(List<decimal> tuple, List<decimal> mean) {
+            double sumSquaredDiffs = 0.0;
+            for (var jx = 0; jx < tuple.Count; jx++) { 
+                sumSquaredDiffs += Math.Pow((double)(tuple[jx] - mean[jx]), 2);
+            }
+            return (decimal)Math.Sqrt(sumSquaredDiffs);
+        }
+
+        /// <summary>
+        /// Index of smallest value in List
+        /// </summary>
+        /// <param name="distances"></param>
+        /// <returns></returns>
+        private static int MinIndex(this List<decimal> distances) {
+            var minDist = distances.Min();
+            return distances.IndexOf(minDist);
+        }
+    }
+}

--- a/GCodeClean/Split/SplitFile.cs
+++ b/GCodeClean/Split/SplitFile.cs
@@ -37,7 +37,7 @@ namespace GCodeClean.Split
             Line prevLine = null;
 
             foreach (var travelling in travellingComments) {
-                var filename = travelling.ParseTravelling().NodeFileName(outputFolder, idFtm);
+                var filename = travelling.ToNode().NodeFileName(outputFolder, idFtm);
                 Console.WriteLine($"Filename: {filename}");
 
                 File.WriteAllLines(filename, preambleLines);

--- a/GCodeClean/Split/SplitFile.cs
+++ b/GCodeClean/Split/SplitFile.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
+using System.Linq;
 
 using GCodeClean.Processing;
 using GCodeClean.Shared;
@@ -20,10 +21,10 @@ namespace GCodeClean.Split
             }
             Directory.CreateDirectory(outputFolder);
 
-            var idFtm = travellingComments.Count.IdFormat();
+            var nodes = travellingComments.Select(tc => tc.ToNode()).ToList();
+            int[] idCounts = [nodes.Select(n => n.Seq).Distinct().Count(), nodes.Select(n => n.SubSeq).Distinct().Count(), nodes.Count];
 
             var iL = inputLines.GetEnumerator();
-
             while (iL.MoveNext()) {
                 var line = iL.Current;
                 if (line == Default.PreambleCompleted) {
@@ -36,8 +37,8 @@ namespace GCodeClean.Split
             var lengthUnits = context.GetLengthUnits();
             Line prevLine = null;
 
-            foreach (var travelling in travellingComments) {
-                var filename = travelling.ToNode().NodeFileName(outputFolder, idFtm);
+            foreach (var node in nodes) {
+                var filename = node.NodeFileName(outputFolder, idCounts);
                 Console.WriteLine($"Filename: {filename}");
 
                 File.WriteAllLines(filename, preambleLines);
@@ -80,7 +81,9 @@ namespace GCodeClean.Split
                         }
                     }
                     File.AppendAllLines(filename, [line]);
-                    if (line.EndsWith(travelling)) {
+                    // Clearing the subSeq value will allow us to rebuild the travelling comment as it appears in the GCode
+                    var unSubSeqNode = node.CopySetSub(0);
+                    if (line.EndsWith(unSubSeqNode.ToTravelling())) {
                         prevLine = new Line(line);
                         break;
                     }

--- a/GCodeClean/Split/SplitFile.cs
+++ b/GCodeClean/Split/SplitFile.cs
@@ -80,10 +80,18 @@ namespace GCodeClean.Split
                             firstLine = false;
                         }
                     }
-                    File.AppendAllLines(filename, [line]);
+
                     // Clearing the subSeq value will allow us to rebuild the travelling comment as it appears in the GCode
                     var unSubSeqNode = node.CopySetSub(0);
-                    if (line.EndsWith(unSubSeqNode.ToTravelling())) {
+                    var origTravelling = unSubSeqNode.ToTravelling();
+                    var travellingFound = line.EndsWith(origTravelling);
+                    if (travellingFound) {
+                        line = line.Replace(origTravelling, node.ToTravelling());
+                    }
+
+                    File.AppendAllLines(filename, [line]);
+
+                    if (travellingFound) {
                         prevLine = new Line(line);
                         break;
                     }

--- a/GCodeClean/Structure/Coord.cs
+++ b/GCodeClean/Structure/Coord.cs
@@ -225,23 +225,23 @@ namespace GCodeClean.Structure
         }
 
         public override string ToString() {
-            var coords = new List<string>();
+            var tokens = new List<Token>();
 
             if ((Set & CoordSet.X) == CoordSet.X) {
-                coords.Add($"X:{X:0.####}");
+                tokens.Add(new Token($"X{X}"));
             }
 
             if ((Set & CoordSet.Y) == CoordSet.Y) {
-                coords.Add($"Y:{Y:0.####}");
+                tokens.Add(new Token($"Y{Y}"));
             }
 
             if ((Set & CoordSet.Z) == CoordSet.Z) {
-                coords.Add($"Z:{Z:0.####}");
+                tokens.Add(new Token($"Z{Z}"));
             }
 
-            return string.Join(',', coords);
+            return string.Join(' ', tokens);
         }
 
-        public string ToXYCoord() => $"X{this.X}Y{this.Y}";
+        public string ToXYCoord() => $"X{X}Y{Y}";
     }
 }

--- a/GCodeClean/Structure/Line.cs
+++ b/GCodeClean/Structure/Line.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
+// Copyright (c) 2020-2024 - Lee HUMPHRIES (lee@md8n.com). All rights reserved.
 // Licensed under the AGPL license. See LICENSE.txt file in the project root for details.
 
 using System;
@@ -174,6 +174,13 @@ namespace GCodeClean.Structure
         /// </summary>
         public bool HasMovementCommand() {
             return !IsArgumentsOnly() && HasTokens(ModalGroup.ModalAllMotion);
+        }
+
+        /// <summary>
+        /// This returns true if there is a Plane Selection Command (G17, G18, G19), comments are ignored for this test
+        /// </summary>
+        public bool HasPlaneSelection() {
+            return !IsArgumentsOnly() && HasTokens(ModalGroup.ModalPlane);
         }
 
         #region Constructors

--- a/GCodeClean/Structure/ModalGroup.cs
+++ b/GCodeClean/Structure/ModalGroup.cs
@@ -40,9 +40,14 @@ namespace GCodeClean.Structure
         public static readonly ImmutableList<Token> ModalNon = [..ModalDwell, ..ModalChangeCoordinateSystemData, ..ModalCoordinateSystemOffset];
 
         /// <summary>
-        /// G Modal subgroup 1 - motion - G0, G1, G2, G3, G38.2
+        /// G Modal subgroup 1 - motion - G0, G1, G2, G3
         /// </summary>
-        public static readonly ImmutableList<Token> ModalSimpleMotion = [new Token("G0"), new Token("G1"), new Token("G2"), new Token(" G3"), new Token("G38.2")];
+        public static readonly ImmutableList<Token> ModalSimpleMotion = [new Token("G0"), new Token("G1"), new Token("G2"), new Token(" G3")];
+
+        /// <summary>
+        /// G Modal subgroup 1 - motion - G38.2
+        /// </summary>
+        public static readonly ImmutableList<Token> ModalProbeMotion = [new Token("G38.2")];
 
         /// <summary>
         /// G Modal subgroup 1 - canned motion - G80, G81, G82, G83, G84, G85, G86, G87, G88, G89
@@ -56,7 +61,7 @@ namespace GCodeClean.Structure
         /// <summary>
         /// G Modal group 1 - motion - G0, G1, G2, G3, G38.2, G80, G81, G82, G83, G84, G85, G86, G87, G88, G89
         /// </summary>
-        public static readonly ImmutableList<Token> ModalMotion = [..ModalSimpleMotion, ..ModalCannedMotion];
+        public static readonly ImmutableList<Token> ModalMotion = [..ModalSimpleMotion, ..ModalProbeMotion, ..ModalCannedMotion];
 
         /// <summary>
         /// G Modal group 1 - collective - simple motion, canned motion, home motion, special motion, G53

--- a/GCodeClean/gcodeclean.csproj
+++ b/GCodeClean/gcodeclean.csproj
@@ -21,6 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Split\KMeans.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />    
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,15 @@ Options:
 
 Each individual file should be a valid GCode file that can be run independently.
 
-The name of these files will be made up of 4 parts, the tool number, the index of the cutting path from the original file (starting at 0), the starting XY coordinate of the cutting path, and the finishing XY coordinate of the cutting path. Each part of the filename is delimited with an underscore `_`.
+The name of these files will be made up of several parts, each part of the filename is delimited with an underscore `_`.
+For a filename like `0_1_17_2_X558.657Y373.418_X563.676Y407.742_gcc.nc` you can understand the parts of it as follows:
+* `0_` - The main 'sequence' number this cutting path belongs to. You can think of this as which tool change has occurred. So this would be the first (`0` based index) tool change.
+* `1_` - The 'sub-sequence' number. The range of cutting depths from the shallowest to the deepest for the entire original file is divided into 10 groupings, and then each cutting path is assigned to one of these groupings depending on its maximum cutting depth. Files in the same 'sequence' and 'sub-sequence' will be grouped together when any merge is performed.
+* `17_` - The original index for this cutting path, i.e. its order in the original file.
+* `2_` - The tool name/number for this cutting path. You may see 'notset' if no tool was defined.
+* `X558.657Y373.418_` - The starting coordinates for this cutting path.
+* `X563.676Y407.742_` - The finishing coordinates.
+* `gcc.nc` - yep it is a GCode (nc) file that GCodeClean has messed with.
 
 
 #### The `merge` Command


### PR DESCRIPTION
# Description

The `Travelling` comment generated by the `clean` command has been restructured. It now identifies a 'sequence', which is a new set of cutting paths for each tool change. And then within that it allows for 'sub-sequences' which are relevant to the `split` and `merge` commands. There's also been some minor bug fixing.

The `split` command aggregates the various cutting paths identified by each `Travelling` comment into 'sub-sequences' depending on the maximum cutting depth. This becomes part of their respective file names.

The `merge` command orders all of the files by the 'sequence' and 'sub-sequence' parts of their names, and reorders each 'sub-sequence' on its own. And then merges all of the files back into one reordered file.